### PR TITLE
Adapt GitHub action for publishing on PyPI

### DIFF
--- a/.github/workflows/check_template_files.yaml
+++ b/.github/workflows/check_template_files.yaml
@@ -5,15 +5,12 @@ on: push
 jobs:
   check-template-files:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
-
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
-
+          python-version: 3.9
       - name: Check template files
         run: |
           if [ "${{ github.event.repository.name }}" == "microservice-repository-template" ]

--- a/.github/workflows/check_template_files.yaml
+++ b/.github/workflows/check_template_files.yaml
@@ -5,12 +5,15 @@ on: push
 jobs:
   check-template-files:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.9"
+
       - name: Check template files
         run: |
           if [ "${{ github.event.repository.name }}" == "microservice-repository-template" ]

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -8,19 +8,14 @@ jobs:
   pypi-publish:
     name: Publish tagged release on PyPI
     runs-on: ubuntu-latest
-    services:
-      rabbitmq:
-        image: rabbitmq:3-management
-        ports:
-          - 5672:5672
-          - 15672:15672
+
     steps:
       - uses: actions/checkout@v3
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.9"
 
       - name: Verify Package Version vs Tag Version
         run: |
@@ -48,6 +43,12 @@ jobs:
           --wheel
           --outdir dist/
           .
+
+      - name: Install testing requirements
+        run: >-
+          python -m
+          pip install
+          -r requirements-dev.txt
 
       - name: Install the newly build package with all extras
         run: |

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -44,18 +44,18 @@ jobs:
           --outdir dist/
           .
 
-      - name: Install testing requirements
-        run: >-
-          python -m
-          pip install
-          -r requirements-dev.txt
-
       - name: Install the newly build package with all extras
         run: |
           TAR_PATH="$( realpath ./dist/*.tar.gz)"
           python3 -m \
             pip install \
             "${TAR_PATH}[all]"
+
+      - name: Install testing requirements
+        run: >-
+          python -m
+          pip install
+          -r requirements-dev.txt
 
       - name: Run pytest on freshly install package
         run: |


### PR DESCRIPTION
The testing requirements are not part of the "all" extra any more. Therefore the GitHub action for publishing on PyPI needs an additional step.