### PR TITLE
Support checking the user status in auth helpers

### DIFF
--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -7,7 +7,7 @@ cd /workspace
 python -m pip install --upgrade pip
 
 # install with all extras in editable mode
-pip install -r requirements.txt
+pip install -e .[all]
 
 # install or upgrade dependencies for development and testing
 pip install --upgrade -r requirements-dev.txt

--- a/.pylintrc
+++ b/.pylintrc
@@ -541,6 +541,6 @@ valid-metaclass-classmethod-first-arg=cls
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when being caught. Defaults to
-# "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+# "builtins.BaseException, builtins.Exception".
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/examples/api/hello_world_web_server/config.py
+++ b/examples/api/hello_world_web_server/config.py
@@ -35,4 +35,4 @@ class Config(ApiConfigBase):
 @lru_cache
 def get_config():
     """Get config parameter."""
-    return Config()
+    return Config()  # pyright: ignore

--- a/examples/auth_demo/auth_demo/auth/policies.py
+++ b/examples/auth_demo/auth_demo/auth/policies.py
@@ -30,7 +30,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from ghga_service_commons.auth.context import AuthContextProtocol
 from ghga_service_commons.auth.policies import (
     get_auth_context_using_credentials,
-    require_auth_token_using_credentials,
+    require_auth_context_using_credentials,
 )
 
 __all__ = ["DemoAuthContext", "get_auth", "require_auth", "require_vip"]
@@ -56,7 +56,7 @@ async def require_auth_context(
     ),
 ) -> DemoAuthContext:
     """Require an authentication and authorization context using FastAPI."""
-    return await require_auth_token_using_credentials(credentials, auth_provider)
+    return await require_auth_context_using_credentials(credentials, auth_provider)
 
 
 def check_vip(context: DemoAuthContext) -> bool:
@@ -72,7 +72,7 @@ async def require_vip_context(
     ),
 ) -> DemoAuthContext:
     """Require a VIP authentication and authorization context using FastAPI."""
-    return await require_auth_token_using_credentials(
+    return await require_auth_context_using_credentials(
         credentials, auth_provider, check_vip
     )
 

--- a/examples/auth_demo/auth_demo/main.py
+++ b/examples/auth_demo/auth_demo/main.py
@@ -44,7 +44,7 @@ def get_configured_app(config: Config) -> FastAPI:
 
 async def configure_and_run_server():
     """Run the HTTP API."""
-    config = Config()
+    config = Config()  # pyright: ignore
     async with get_configured_container(config) as container:
         container.wire(modules=["auth_demo.router", "auth_demo.auth.policies"])
         app = get_configured_app(config)

--- a/examples/auth_demo/tests_auth_demo/integration/test_api.py
+++ b/examples/auth_demo/tests_auth_demo/integration/test_api.py
@@ -27,7 +27,7 @@ from pytest import fixture
 
 async def get_app() -> FastAPI:
     """Get the demo app."""
-    config = Config()
+    config = Config()  # pyright: ignore
     async with get_configured_container(config) as container:
         container.wire(modules=["auth_demo.router", "auth_demo.auth.policies"])
         return get_configured_app(config)

--- a/examples/ghga_auth/ghga_auth/main.py
+++ b/examples/ghga_auth/ghga_auth/main.py
@@ -44,7 +44,7 @@ def get_configured_app(config: Config) -> FastAPI:
 
 async def configure_and_run_server():
     """Run the HTTP API."""
-    config = Config()
+    config = Config()  # pyright: ignore
     async with get_configured_container(config) as container:
         container.wire(modules=["ghga_auth.router"])
         app = get_configured_app(config)

--- a/examples/ghga_auth/ghga_auth/policies.py
+++ b/examples/ghga_auth/ghga_auth/policies.py
@@ -28,13 +28,13 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from ghga_auth.container import Container  # type: ignore
 
 from ghga_service_commons.auth.context import AuthContextProtocol
-from ghga_service_commons.auth.ghga import AuthContext, has_role
+from ghga_service_commons.auth.ghga import AuthContext, has_role, is_active
 from ghga_service_commons.auth.policies import (
     get_auth_context_using_credentials,
-    require_auth_token_using_credentials,
+    require_auth_context_using_credentials,
 )
 
-__all__ = ["AuthContext", "get_auth", "require_auth", "require_admin"]
+__all__ = ["AuthContext", "get_auth", "require_admin", "require_active", "require_auth"]
 
 
 @inject
@@ -57,7 +57,20 @@ async def require_auth_context(
     ),
 ) -> AuthContext:
     """Require a GHGA authentication and authorization context using FastAPI."""
-    return await require_auth_token_using_credentials(credentials, auth_provider)
+    return await require_auth_context_using_credentials(credentials, auth_provider)
+
+
+@inject
+async def require_active_context(
+    credentials: HTTPAuthorizationCredentials = Depends(HTTPBearer(auto_error=True)),
+    auth_provider: AuthContextProtocol[AuthContext] = Depends(
+        Provide[Container.auth_provider]
+    ),
+) -> AuthContext:
+    """Require an active GHGA auth context using FastAPI."""
+    return await require_auth_context_using_credentials(
+        credentials, auth_provider, is_active
+    )
 
 
 is_admin = partial(has_role, role="admin")
@@ -70,17 +83,20 @@ async def require_admin_context(
         Provide[Container.auth_provider]
     ),
 ) -> AuthContext:
-    """Require a VIP authentication and authorization context using FastAPI."""
-    return await require_auth_token_using_credentials(
+    """Require an active GHGA auth context with admin role using FastAPI."""
+    return await require_auth_context_using_credentials(
         credentials, auth_provider, is_admin
     )
 
 
-# policy for getting an auth token without requiring its existence
+# policy for getting an auth context without requiring its existence
 get_auth = Security(get_auth_context)
 
-# policy for requiring and getting an auth token
+# policy for requiring and getting an auth context
 require_auth = Security(require_auth_context)
 
-# policy fo requiring and getting an auth token with admin role
+# policy for requiring and getting an active auth context
+require_active = Security(require_active_context)
+
+# policy fo requiring and getting an active auth context with admin role
 require_admin = Security(require_admin_context)

--- a/examples/ghga_auth/ghga_auth/router.py
+++ b/examples/ghga_auth/ghga_auth/router.py
@@ -19,7 +19,13 @@
 from typing import Optional
 
 from fastapi import APIRouter
-from ghga_auth.policies import AuthContext, get_auth, require_admin, require_auth
+from ghga_auth.policies import (
+    AuthContext,
+    get_auth,
+    require_active,
+    require_admin,
+    require_auth,
+)
 
 router = APIRouter()
 
@@ -36,7 +42,13 @@ async def require_auth_route(context: AuthContext = require_auth):
     return {"context": context.dict()}
 
 
+@router.get("/require_active")
+async def require_active_route(context: AuthContext = require_active):
+    """Require and return active auth context."""
+    return {"context": context.dict()}
+
+
 @router.get("/require_admin")
 async def require_admin_route(context: AuthContext = require_admin):
-    """Require and return auth context with admin role."""
+    """Require and return active auth context with admin role."""
     return {"context": context.dict()}

--- a/ghga_service_commons/__init__.py
+++ b/ghga_service_commons/__init__.py
@@ -15,4 +15,4 @@
 
 """A library that contains the common functionality used in services of GHGA"""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/ghga_service_commons/auth/ghga.py
+++ b/ghga_service_commons/auth/ghga.py
@@ -25,7 +25,14 @@ from pydantic import BaseModel, EmailStr, Field
 from ghga_service_commons.auth.jwt_auth import JWTAuthConfig, JWTAuthContextProvider
 from ghga_service_commons.utils.utc_dates import DateTimeUTC
 
-__all__ = ["AcademicTitle", "AuthConfig", "AuthContext", "UserStatus", "has_role"]
+__all__ = [
+    "AcademicTitle",
+    "AuthConfig",
+    "AuthContext",
+    "UserStatus",
+    "has_role",
+    "is_active",
+]
 
 
 class UserStatus(str, Enum):
@@ -80,8 +87,15 @@ class AuthContext(BaseModel):
     )
 
 
+def is_active(context: AuthContext) -> bool:
+    """Check whether the given context has an active status."""
+    return context.status is UserStatus.ACTIVE
+
+
 def has_role(context: AuthContext, role: str) -> bool:
-    """Check whether the given context has the given role."""
+    """Check whether the given context is active and has the given role."""
+    if not is_active(context):
+        return False
     user_role = context.role
     if user_role and "@" not in role:
         user_role = user_role.split("@", 1)[0]

--- a/ghga_service_commons/auth/policies.py
+++ b/ghga_service_commons/auth/policies.py
@@ -27,7 +27,10 @@ from starlette.status import HTTP_403_FORBIDDEN
 
 from ghga_service_commons.auth.context import AuthContext, AuthContextProtocol
 
-__all__ = ["get_auth_context_using_credentials", "require_auth_token_using_credentials"]
+__all__ = [
+    "get_auth_context_using_credentials",
+    "require_auth_context_using_credentials",
+]
 
 
 async def get_auth_context_using_credentials(
@@ -50,7 +53,7 @@ async def get_auth_context_using_credentials(
         ) from error
 
 
-async def require_auth_token_using_credentials(
+async def require_auth_context_using_credentials(
     credentials: HTTPAuthorizationCredentials,
     auth_provider: AuthContextProtocol[AuthContext],
     predicate: Callable[[AuthContext], bool] = lambda _context: True,

--- a/tests/unit/auth/test_policies.py
+++ b/tests/unit/auth/test_policies.py
@@ -27,7 +27,7 @@ from starlette.status import HTTP_403_FORBIDDEN
 from ghga_service_commons.auth.context import AuthContextProtocol
 from ghga_service_commons.auth.policies import (
     get_auth_context_using_credentials,
-    require_auth_token_using_credentials,
+    require_auth_context_using_credentials,
 )
 
 
@@ -76,7 +76,7 @@ async def test_require_auth_context_no_token():
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="")
     auth_provider = DummyAuthProvider()
     with raises(HTTPException) as exc_info:
-        await require_auth_token_using_credentials(credentials, auth_provider)
+        await require_auth_context_using_credentials(credentials, auth_provider)
     assert exc_info.value.status_code == HTTP_403_FORBIDDEN
     assert exc_info.value.detail == "Not authenticated"
 
@@ -86,7 +86,7 @@ async def test_require_auth_context_with_token():
     """Test passing a token to the require_auth_context function."""
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="foo")
     auth_provider = DummyAuthProvider()
-    context = await require_auth_token_using_credentials(credentials, auth_provider)
+    context = await require_auth_context_using_credentials(credentials, auth_provider)
     assert context is not None
     assert context.token == "foo"
 
@@ -96,7 +96,7 @@ async def test_require_auth_context_with_happy_predicate():
     """Test the happy path of the require_auth_context function with a predicate."""
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="foo")
     auth_provider = DummyAuthProvider()
-    context = await require_auth_token_using_credentials(
+    context = await require_auth_context_using_credentials(
         credentials, auth_provider, dummy_predicate
     )
     assert context is not None
@@ -109,7 +109,7 @@ async def test_require_auth_context_with_unhappy_predicate():
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="bar")
     auth_provider = DummyAuthProvider()
     with raises(HTTPException) as exc_info:
-        await require_auth_token_using_credentials(
+        await require_auth_context_using_credentials(
             credentials, auth_provider, dummy_predicate
         )
     assert exc_info.value.status_code == HTTP_403_FORBIDDEN


### PR DESCRIPTION
Small addition to the GHGA auth helpers and example: The status should always be considered. Also fix names to be consistent ("context" instead of "token").