### PR TITLE
Add utils for encryption and decryption (GSI-97)

### DIFF
--- a/.deprecated_files
+++ b/.deprecated_files
@@ -8,6 +8,7 @@
 .devcontainer/library-scripts
 
 .github/workflows/check_mandatory_and_static_files.yaml
+.github/workflows/dev_cd.yaml
 
 scripts/check_mandatory_and_static_files.py
 scripts/update_static_files.py

--- a/.mandatory_files
+++ b/.mandatory_files
@@ -10,7 +10,6 @@
 .devcontainer/docker-compose.yml
 .devcontainer/Dockerfile
 
-.github/workflows/dev_cd.yaml
 
 docs/README.md
 

--- a/.mandatory_files_ignore
+++ b/.mandatory_files_ignore
@@ -3,8 +3,6 @@
 
 .devcontainer/dev_launcher
 
-.github/workflows/dev_cd.yaml
-
 scripts/script_utils/fastapi_app_location.py
 
 Dockerfile

--- a/.static_files
+++ b/.static_files
@@ -27,6 +27,7 @@ scripts/README.md
 .github/workflows/static_code_analysis.yaml
 .github/workflows/unit_and_int_tests.yaml
 .github/workflows/check_openapi_spec.yaml
+.github/workflows/cd.yaml
 
 example_data/README.md
 

--- a/.static_files_ignore
+++ b/.static_files_ignore
@@ -6,6 +6,7 @@ scripts/update_openapi_docs.py
 
 .github/workflows/check_config_docs.yaml
 .github/workflows/check_openapi_spec.yaml
+.github/workflows/cd.yaml
 
 .devcontainer/dev_install
 .devcontainer/Dockerfile

--- a/ghga_service_commons/__init__.py
+++ b/ghga_service_commons/__init__.py
@@ -15,4 +15,4 @@
 
 """A library that contains the common functionality used in services of GHGA"""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/ghga_service_commons/utils/crypt.py
+++ b/ghga_service_commons/utils/crypt.py
@@ -39,7 +39,7 @@ class KeyPair(NamedTuple):
 
 
 def generate_key_pair() -> KeyPair:
-    """Generate a Curve25519 key pair (as used in Crypt4GH)."""
+    """Generate a Curve25519 key pair as used in Crypt4GH."""
     keys = PrivateKey.generate()
     return KeyPair(bytes(keys), bytes(keys.public_key))
 
@@ -97,18 +97,23 @@ def decrypt(
 
 
 def encrypt(
-    data: str, key: Union[bytes, str, PublicKey], encoding: str = "utf-8"
+    data: str, key: Union[bytes, str, PrivateKey, PublicKey], encoding: str = "utf-8"
 ) -> str:
     """Encrypt a str with given encoding using a public Crypt4GH key.
 
     The result will be returned as a base64 encoded string.
 
     Raises a ValueError if the given key cannot be used for encryption.
+
+    A PrivateKey object can be passed as key as well, then the derived public key
+    will be used for the encryption.
     """
     if isinstance(key, str):
         key = decode_key(key)
     if isinstance(key, bytes):
         key = PublicKey(key)
+    if isinstance(key, PrivateKey):
+        key = key.public_key
     if not isinstance(key, PublicKey):
         raise ValueError("Invalid key")
     sealed_box = SealedBox(key)

--- a/ghga_service_commons/utils/crypt.py
+++ b/ghga_service_commons/utils/crypt.py
@@ -75,7 +75,7 @@ def decode_key(key: str) -> bytes:
 
 
 def decrypt(
-    data: Union[bytes, str], key: Union[bytes, str, PrivateKey], encoding: str = "ascii"
+    data: Union[bytes, str], key: Union[bytes, str, PrivateKey], encoding: str = "utf-8"
 ) -> str:
     """Decrypt a base64 encoded or bytes string using a private Crypt4GH key.
 
@@ -97,7 +97,7 @@ def decrypt(
 
 
 def encrypt(
-    data: str, key: Union[bytes, str, PublicKey], encoding: str = "ascii"
+    data: str, key: Union[bytes, str, PublicKey], encoding: str = "utf-8"
 ) -> str:
     """Encrypt a str with given encoding using a public Crypt4GH key.
 

--- a/ghga_service_commons/utils/crypt.py
+++ b/ghga_service_commons/utils/crypt.py
@@ -1,0 +1,95 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Helper functions for Crypt4GH compliant encryption."""
+
+import base64
+
+from nacl.public import PrivateKey, PublicKey, SealedBox
+
+__all__ = [
+    "generate_key_pair",
+    "encode_private_key",
+    "encode_public_key",
+    "decode_private_key",
+    "decode_public_key",
+    "decrypt",
+    "encrypt",
+]
+
+
+def generate_key_pair() -> PrivateKey:
+    """Generate a Curve25519 key pair (as used in Crypt4GH)."""
+    return PrivateKey.generate()
+
+
+def encode_private_key(key_pair: PrivateKey) -> str:
+    """Get base64 encoded private key from the given key pair."""
+    return base64.b64encode(bytes(key_pair)).decode("ascii")
+
+
+def encode_public_key(key_pair: PrivateKey) -> str:
+    """Get base64 encoded public key from the given key pair."""
+    return base64.b64encode(bytes(key_pair.public_key)).decode("ascii")
+
+
+def decode_private_key(key: str) -> PrivateKey:
+    """Get the given base64 encoded private key as a PrivateKey object.
+
+    This function can be used to check whether this is a valid base64 encoded string
+    of the right length; it raises a ValueError if this is not the case.
+    """
+    try:
+        decoded_key = base64.b64decode(key)
+    except base64.binascii.Error as error:  # type: ignore
+        raise ValueError(str(error)) from error
+    if len(decoded_key) != 32:
+        raise ValueError("The raw private key must be 32 bytes long.")
+    return PrivateKey(decoded_key)
+
+
+def decode_public_key(key: str) -> PublicKey:
+    """Get the given base64 encoded public key as a PublicKey object.
+
+    This function can be used to check whether this is a valid base64 encoded string
+    of the right length; it raises a ValueError if this is not the case.
+    """
+    try:
+        decoded_key = base64.b64decode(key)
+    except base64.binascii.Error as error:  # type: ignore
+        raise ValueError(str(error)) from error
+    if len(decoded_key) != 32:
+        raise ValueError("The raw public key must be 32 bytes long.")
+    return PublicKey(decoded_key)
+
+
+def decrypt(data: str, key: str) -> str:
+    """Decrypt a str of ASCII characters with a base64 encoded private Crypt4GH key."""
+    sealed_box = SealedBox(decode_private_key(key))
+    encrypted_bytes = base64.b64decode(data)
+    decrypted_bytes = sealed_box.decrypt(encrypted_bytes)
+    return decrypted_bytes.decode("ascii")
+
+
+def encrypt(data: str, key: str) -> str:
+    """Encrypt a str of ASCII characters with a base64 encoded public Crypt4GH key.
+
+    The result will be base64 encoded again.
+    """
+    sealed_box = SealedBox(decode_public_key(key))
+    decoded_data = bytes(data, encoding="ascii")
+    encrypted = sealed_box.encrypt(decoded_data)
+    return base64.b64encode(encrypted).decode("ascii")

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,9 +54,12 @@ api =
 auth =
     jwcrypto==1.4.2
     pydantic[email]==1.10.6
+crypt =
+    pynacl==1.5.0
 all =
     %(api)s
     %(auth)s
+    %(crypt)s
 
 [options.packages.find]
 exclude = tests

--- a/tests/unit/utils/test_crypt.py
+++ b/tests/unit/utils/test_crypt.py
@@ -162,7 +162,7 @@ def test_encrypt_same_message_twice():
 
 
 def test_encrypted_is_encoded_and_raw_data_can_be_decrypted():
-    """Test that encrypted data is base64 encoded and that raw data cab be decrypted."""
+    """Test that encrypted data is base64 encoded and that raw data can be decrypted."""
     key_pair = generate_key_pair()
 
     message = "Foo bar baz!"

--- a/tests/unit/utils/test_crypt.py
+++ b/tests/unit/utils/test_crypt.py
@@ -126,6 +126,22 @@ def test_encryption_and_decryption_with_key_objects():
     assert decrypted == message
 
 
+def test_encryption_and_decryption_with_private_key_only():
+    """Test encrypting and decrypting with private key and derived public key."""
+    key_pair = generate_key_pair()
+    private_key = PrivateKey(key_pair.private)
+
+    message = "Foo bar baz!"
+
+    encrypted = encrypt(message, private_key)
+    assert isinstance(encrypted, str)
+    assert encrypted != message
+
+    decrypted = decrypt(encrypted, private_key)
+    assert isinstance(decrypted, str)
+    assert decrypted == message
+
+
 def test_encryption_with_encoded_and_decryption_with_raw_key():
     """Test encrypting with base64 encoded key and decrypting with raw key."""
     key_pair = generate_key_pair()

--- a/tests/unit/utils/test_crypt.py
+++ b/tests/unit/utils/test_crypt.py
@@ -181,10 +181,11 @@ def test_encryption_and_decryption_with_non_ascii_data():
     key_pair = generate_key_pair()
 
     message = "Ƒø båřȑ bāç‼"
+    assert not message.isascii()
 
     encrypted = encrypt(message, key_pair.public)
     assert isinstance(encrypted, str)
-    assert encrypted != message
+    assert encrypted.isascii()
 
     decrypted = decrypt(encrypted, key_pair.private)
     assert isinstance(decrypted, str)

--- a/tests/unit/utils/test_crypt.py
+++ b/tests/unit/utils/test_crypt.py
@@ -1,0 +1,109 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Test the cryptographic utilities."""
+
+
+import base64
+
+from pytest import raises
+
+from ghga_service_commons.utils.crypt import (
+    decode_private_key,
+    decode_public_key,
+    decrypt,
+    encode_private_key,
+    encode_public_key,
+    encrypt,
+    generate_key_pair,
+)
+
+
+def test_generate_key_pair():
+    """Test that random key pairs can be generated."""
+    key_pair = generate_key_pair()
+    assert hasattr(key_pair, "public_key")
+    another_key_pair = generate_key_pair()
+    assert key_pair != another_key_pair
+    assert bytes(key_pair) != bytes(another_key_pair)
+    assert bytes(key_pair.public_key) != bytes(another_key_pair.public_key)
+
+
+def test_encode_key_pair():
+    """Test that key pairs can be base64 encoded."""
+    key_pair = generate_key_pair()
+    encoded_private_key = encode_private_key(key_pair)
+    assert isinstance(encoded_private_key, str)
+    assert encoded_private_key.isascii()
+    assert len(encoded_private_key) == 44
+    encoded_public_key = encode_public_key(key_pair)
+    assert isinstance(encoded_public_key, str)
+    assert encoded_public_key.isascii()
+    assert len(encoded_public_key) == 44
+    assert encode_public_key != encode_private_key
+
+
+def test_decode_valid_private_key():
+    """Test that valid base64 encoded private keys can be decoded."""
+    key = decode_private_key(base64.b64encode(b"foo4" * 8).decode("ascii"))
+    assert bytes(key) == b"foo4" * 8
+
+
+def test_decode_invalid_private_key():
+    """Test that invalid private keys can be detected."""
+    with raises(ValueError, match="Incorrect padding"):
+        decode_private_key("foo")
+    with raises(ValueError, match="raw private key must be 32 bytes long"):
+        decode_private_key(base64.b64encode(b"foo").decode("ascii"))
+
+
+def test_decode_valid_public_key():
+    """Test that valid base64 encoded public keys can be decoded."""
+    key = decode_public_key(base64.b64encode(b"foo4" * 8).decode("ascii"))
+    assert bytes(key) == b"foo4" * 8
+
+
+def test_decode_invalid_public_key():
+    """Test that invalid public keys can be detected."""
+    with raises(ValueError, match="Incorrect padding"):
+        decode_public_key("foo")
+    with raises(ValueError, match="raw public key must be 32 bytes long"):
+        decode_public_key(base64.b64encode(b"foo").decode("ascii"))
+    decode_public_key(base64.b64encode(b"foo4" * 8).decode("ascii"))
+
+
+def test_decode_generated_key_pair():
+    """Test that a generated key pair can be encoded and decoded."""
+    key_pair = generate_key_pair()
+    decode_private_key(encode_private_key(key_pair))
+    decode_public_key(encode_public_key(key_pair))
+
+
+def test_encryption_and_decryption():
+    """Test encrypting and decrypting a message."""
+    key_pair = generate_key_pair()
+    private_key = encode_private_key(key_pair)
+    assert isinstance(private_key, str)
+    public_key = encode_public_key(key_pair)
+    assert isinstance(public_key, str)
+
+    message = "Foo bar baz!"
+    encrypted = encrypt(message, public_key)
+    assert isinstance(encrypted, str)
+    assert encrypted != message
+    decrypted = decrypt(encrypted, private_key)
+    assert isinstance(decrypted, str)
+    assert decrypted == message

--- a/tests/unit/utils/test_crypt.py
+++ b/tests/unit/utils/test_crypt.py
@@ -174,3 +174,18 @@ def test_encrypted_is_encoded_and_raw_data_can_be_decrypted():
     decrypted = decrypt(encrypted_raw, key_pair.private)
     assert isinstance(decrypted, str)
     assert decrypted == message
+
+
+def test_encryption_and_decryption_with_non_ascii_data():
+    """Test encrypting and decrypting a non ASCII message with raw keys."""
+    key_pair = generate_key_pair()
+
+    message = "Ƒø båřȑ bāç‼"
+
+    encrypted = encrypt(message, key_pair.public)
+    assert isinstance(encrypted, str)
+    assert encrypted != message
+
+    decrypted = decrypt(encrypted, key_pair.private)
+    assert isinstance(decrypted, str)
+    assert decrypted == message


### PR DESCRIPTION
This PR adds helper functions for encryption and decryption using Crypt4GH keys to the service commons library.

Provided are also functions to generate random keys and encode and decode them as Base64 encoded ASCII strings so that they can be exchanges more easily.

This simplifies the implementation of services that are using this functionality, avoids code duplication and ensures that the services are compatible with each other and Crypt4GH.