### PR TITLE
Bumped httpyexpect to version including workaround

### DIFF
--- a/ghga_service_commons/__init__.py
+++ b/ghga_service_commons/__init__.py
@@ -15,4 +15,4 @@
 
 """A library that contains the common functionality used in services of GHGA"""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ console_scripts =
 api =
     fastapi==0.94.1
     uvicorn[standard]==0.20.0
-    httpyexpect==0.2.4
+    httpyexpect==0.2.5
     httpx==0.23.3
 auth =
     jwcrypto==1.4.2


### PR DESCRIPTION
Httpyexpect also had its own pydantic + typing.Literal issue in 0.2.4.
Bumped version to include the workaround.