### PR TITLE
Add general exception handling (GSI 331)

### DIFF
--- a/ghga_service_commons/__init__.py
+++ b/ghga_service_commons/__init__.py
@@ -15,4 +15,4 @@
 
 """A library that contains the common functionality used in services of GHGA"""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/ghga_service_commons/api/mock_router.py
+++ b/ghga_service_commons/api/mock_router.py
@@ -123,7 +123,7 @@ class MockRouter(Generic[ExpectedExceptionTypes]):
             `exceptions_to_handle`:
                 tuple containing the exception types to pass to the exception_handler.
                 This parameter has no effect if `exception_handler` is None.
-                If None, all exceptions will be passed to the handler. If provided, only
+                If None, no exceptions will be passed to the handler. If provided, only
                 the exceptions specified will be passed to the handler. All other exception
                 types will be re-raised.
 
@@ -390,7 +390,7 @@ class MockRouter(Generic[ExpectedExceptionTypes]):
     def _should_pass_to_handler(self, exc: Exception):
         """Determine whether the provided exception should be passed to the handler"""
         if not self.exceptions_to_handle:
-            return True
+            return False
 
         pass_to_handler = False
         for exc_type in self.exceptions_to_handle:
@@ -413,9 +413,8 @@ class MockRouter(Generic[ExpectedExceptionTypes]):
         httpx_mock.add_callback(callback=mock_router.handle_request)
         ```
         If self.exception_handler is specified, any errors matching self.exceptions_to_handle
-        will be passed to the handler. If self.exceptions_to_handle is None, then the
-        handler will be given the exception regardless of type. In all other cases,
-        the exception will be re-raised.
+        will be passed to the handler. In all other cases, the exception will be
+        re-raised.
         """
 
         try:

--- a/ghga_service_commons/api/mock_router.py
+++ b/ghga_service_commons/api/mock_router.py
@@ -106,7 +106,7 @@ class MockRouter(Generic[E]):
     def __init__(
         self,
         exception_handler: Optional[Callable[[httpx.Request, E], Any]] = None,
-        exceptions_to_catch: Optional[tuple[Type[Exception], ...]] = None,
+        exceptions_to_handle: Optional[tuple[Type[Exception], ...]] = None,
         handle_exc_subclasses: bool = False,
     ):
         """Initialize the MockRouter with an optional exception handler.
@@ -118,7 +118,7 @@ class MockRouter(Generic[E]):
                 the first argument and any subclass of Exception as the second argument.
                 This allows your exception handler signature to be more specifically typed.
 
-            `exceptions_to_catch`:
+            `exceptions_to_handle`:
                 tuple containing the exception types to pass to the exception_handler.
                 This parameter has no effect if `exception_handler` is None.
                 If None, all exceptions will be passed to the handler. If provided, only
@@ -131,7 +131,7 @@ class MockRouter(Generic[E]):
                 matches will be passed to the handler.
         """
         self.exception_handler = exception_handler
-        self.exceptions_to_catch = exceptions_to_catch
+        self.exceptions_to_handle = exceptions_to_handle
         self.handle_exc_subclasses = handle_exc_subclasses
 
         self._methods: dict[str, list[RegisteredEndpoint]] = {
@@ -387,11 +387,11 @@ class MockRouter(Generic[E]):
 
     def _should_pass_to_handler(self, exc: Exception):
         """Determine whether the provided exception should be passed to the handler"""
-        if not self.exceptions_to_catch:
+        if not self.exceptions_to_handle:
             return True
 
         pass_to_handler = False
-        for exc_type in self.exceptions_to_catch:
+        for exc_type in self.exceptions_to_handle:
             if isinstance(exc, exc_type):
                 if (
                     not self.handle_exc_subclasses
@@ -410,8 +410,8 @@ class MockRouter(Generic[E]):
         ```
         httpx_mock.add_callback(callback=mock_router.handle_request)
         ```
-        If self.exception_handler is specified, any errors matching self.exceptions_to_catch
-        will be passed to the handler. If self.exceptions_to_catch is None, then the
+        If self.exception_handler is specified, any errors matching self.exceptions_to_handle
+        will be passed to the handler. If self.exceptions_to_handle is None, then the
         handler will be given the exception regardless of type. In all other cases,
         the exception will be re-raised.
         """

--- a/ghga_service_commons/api/mock_router.py
+++ b/ghga_service_commons/api/mock_router.py
@@ -22,8 +22,6 @@ from typing import Any, Callable, Generic, Optional, Type, TypeVar, cast, get_ty
 
 import httpx
 import pytest
-from fastapi import HTTPException
-from httpx import HTTPError
 from pydantic import BaseModel
 
 from ghga_service_commons.httpyexpect.server.exceptions import HttpException
@@ -32,8 +30,6 @@ __all__ = [
     "MockRouter",
     "assert_all_responses_were_requested",
     "HttpException",
-    "HTTPException",
-    "HTTPError",
 ]
 
 BRACKET_PATTERN = re.compile(r"{.*?}")

--- a/tests/integration/fixtures/mock_api.py
+++ b/tests/integration/fixtures/mock_api.py
@@ -22,7 +22,7 @@ from ghga_service_commons.api.mock_router import MockRouter
 from ghga_service_commons.httpyexpect.server.exceptions import HttpException
 
 # Create an instance of the MockRouter with no exception handler
-app: MockRouter = MockRouter()
+app: MockRouter = MockRouter(exceptions_to_handle=(HttpException,))
 
 
 # basic way to register an endpoint

--- a/tests/integration/fixtures/mock_api.py
+++ b/tests/integration/fixtures/mock_api.py
@@ -22,7 +22,7 @@ from ghga_service_commons.api.mock_router import MockRouter
 from ghga_service_commons.httpyexpect.server.exceptions import HttpException
 
 # Create an instance of the MockRouter with no exception handler
-app = MockRouter()
+app: MockRouter = MockRouter()
 
 
 # basic way to register an endpoint

--- a/tests/integration/test_mock_router.py
+++ b/tests/integration/test_mock_router.py
@@ -198,7 +198,7 @@ def test_handler_errors_filtering(httpx_mock: HTTPXMock):  # noqa: F811
 
     throwaway: MockRouter = MockRouter(
         exception_handler=handler,
-        exceptions_to_catch=(ValueError,),
+        exceptions_to_handle=(ValueError,),
     )
 
     @throwaway.get("/gotohandler")
@@ -229,10 +229,10 @@ def test_handler_errors_filtering(httpx_mock: HTTPXMock):  # noqa: F811
 
 
 def test_exceptions_no_handler(httpx_mock: HTTPXMock):  # noqa: F811
-    """Errors specified in http_exceptions_to_catch should be raised normally if
+    """Errors specified in http_exceptions_to_handle should be raised normally if
     http_exception_handler is not defined"""
     throwaway: MockRouter = MockRouter(
-        exceptions_to_catch=(HttpException, HTTPException)
+        exceptions_to_handle=(HttpException, HTTPException)
     )
 
     @throwaway.get("/")

--- a/tests/integration/test_mock_router.py
+++ b/tests/integration/test_mock_router.py
@@ -16,8 +16,11 @@
 
 """Tests for the MockRouter class"""
 
+from typing import Union
+
 import httpx
 import pytest
+from fastapi import HTTPException
 from pytest_httpx import HTTPXMock, httpx_mock  # noqa: F401
 
 from ghga_service_commons.api.mock_router import (  # noqa: F401
@@ -141,7 +144,7 @@ def test_post_failure_with_handler(httpx_mock: HTTPXMock):  # noqa: F811
 
     Makes sure that exceptions are handled with the specified handler.
     """
-    app.http_exception_handler = http_exception_handler
+    app.exception_handler = http_exception_handler
     httpx_mock.add_callback(callback=app.handle_request)
 
     # cause a failure by omitting the "detail" key that the endpoint looks for
@@ -155,7 +158,7 @@ def test_path_and_function_mismatch():
     """
 
     # create a new MockRouter so we don't modify 'app'
-    throwaway = MockRouter()
+    throwaway: MockRouter = MockRouter()
 
     with pytest.raises(
         TypeError,
@@ -171,7 +174,7 @@ def test_endpoint_missing_typehint():
     """Make sure that we get an error when a registered endpoint lacks type hints"""
 
     # create a new MockRouter so we don't modify 'app'
-    throwaway = MockRouter()
+    throwaway: MockRouter = MockRouter()
 
     with pytest.raises(
         TypeError,
@@ -181,3 +184,63 @@ def test_endpoint_missing_typehint():
         @throwaway.get("/dummy/{parameter1}")
         def dummy(parameter1) -> None:
             """Dummy function with missing type-hint info"""
+
+
+def test_handler_errors_filtering(httpx_mock: HTTPXMock):  # noqa: F811
+    """When a handler is provided and errors are specified, make sure only the specified
+    errors are passed to the handler, and that all other types are raised again."""
+
+    class TestValueError(ValueError):
+        """Subclass of ValueError to test handle_exc_subclasses"""
+
+    def handler(request: httpx.Request, exc: Union[ValueError, TestValueError]):
+        return httpx.Response(status_code=500)
+
+    throwaway: MockRouter = MockRouter(
+        exception_handler=handler,
+        exceptions_to_catch=(ValueError,),
+    )
+
+    @throwaway.get("/gotohandler")
+    def succeeds():
+        raise ValueError()  # will get passed to handler
+
+    @throwaway.get("/raise")
+    def fails():
+        raise HttpException(  # won't get passed to handler and will thus be re-raised
+            status_code=404, exception_id="test", description="test", data={}
+        )
+
+    @throwaway.get("/raise2")
+    def fails_also():  # will only get passed to error if we set handle_exc_subclasses
+        raise TestValueError()
+
+    httpx_mock.add_callback(callback=throwaway.handle_request)
+
+    with httpx.Client(base_url=BASE_URL) as client:
+        client.get("/gotohandler")
+        with pytest.raises(HttpException):
+            client.get("/raise")
+        with pytest.raises(TestValueError):
+            client.get("/raise2")
+
+        throwaway.handle_exc_subclasses = True
+        client.get("/raise2")
+
+
+def test_exceptions_no_handler(httpx_mock: HTTPXMock):  # noqa: F811
+    """Errors specified in http_exceptions_to_catch should be raised normally if
+    http_exception_handler is not defined"""
+    throwaway: MockRouter = MockRouter(
+        exceptions_to_catch=(HttpException, HTTPException)
+    )
+
+    @throwaway.get("/")
+    def raise_an_error():
+        raise HTTPException(status_code=404)
+
+    httpx_mock.add_callback(callback=throwaway.handle_request)
+
+    with httpx.Client(base_url=BASE_URL) as client:
+        with pytest.raises(HTTPException):
+            client.get("/")

--- a/tests/integration/test_mock_router.py
+++ b/tests/integration/test_mock_router.py
@@ -191,7 +191,7 @@ def test_handler_errors_filtering(httpx_mock: HTTPXMock):  # noqa: F811
     errors are passed to the handler, and that all other types are raised again."""
 
     class TestValueError(ValueError):
-        """Subclass of ValueError to test handle_exc_subclasses"""
+        """Subclass of ValueError to test handle_exception_subclasses"""
 
     def handler(request: httpx.Request, exc: Union[ValueError, TestValueError]):
         return httpx.Response(status_code=500)
@@ -212,7 +212,7 @@ def test_handler_errors_filtering(httpx_mock: HTTPXMock):  # noqa: F811
         )
 
     @throwaway.get("/raise2")
-    def fails_also():  # will only get passed to error if we set handle_exc_subclasses
+    def fails_also():  # will only get passed to error if we set handle_exception_subclasses
         raise TestValueError()
 
     httpx_mock.add_callback(callback=throwaway.handle_request)
@@ -224,13 +224,13 @@ def test_handler_errors_filtering(httpx_mock: HTTPXMock):  # noqa: F811
         with pytest.raises(TestValueError):
             client.get("/raise2")
 
-        throwaway.handle_exc_subclasses = True
+        throwaway.handle_exception_subclasses = True
         client.get("/raise2")
 
 
 def test_exceptions_no_handler(httpx_mock: HTTPXMock):  # noqa: F811
-    """Errors specified in http_exceptions_to_handle should be raised normally if
-    http_exception_handler is not defined"""
+    """Errors specified in exceptions_to_handle should be raised normally if
+    exception_handler is not defined"""
     throwaway: MockRouter = MockRouter(
         exceptions_to_handle=(HttpException, HTTPException)
     )


### PR DESCRIPTION
Adds better error handling options. Abandoned the idea of handling http-specific errors and instead allow for any kind of exceptions to be handled with the provided handler function. 
New MockRouter use is:
```python
def exception_handler(request: httpx.Request, exc: Union[ValueError, HttpException]):
    if isinstance(exc, ValueError):
        # do something
    else:
        # do something else


router = MockRouter(
    exception_handler=exception_handler, 
    exceptions_to_catch=(ValueError, HttpException), 
    handle_exc_subclasses=True
)

# router will now pass ValueErrors, HttpExceptions, and anything subclassing them to the exception_handler function. 
```