### PR TITLE
Update pypi_publish.yaml for pyproject.toml (GSI 376)

### DIFF
--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Verify Package Version vs Tag Version
         run: |
-          PKG_VER="$(python setup.py -V)"
+          PKG_VER="$(grep -oP 'version = "\K[^"]+' pyproject.toml)"
           TAG_VER="${GITHUB_REF##*/}"
           echo "Package version is $PKG_VER" >&2
           echo "Tag version is $TAG_VER" >&2


### PR DESCRIPTION
Fix the remaining reference to `setup.py` that was in the script so it now gets the package version from `pyproject.toml` via `grep`.