### PR TITLE
add utils for dependency injection (GSI-443)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghga_service_commons"
-version = "0.8.0"
+version = "1.0.0"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [

--- a/src/ghga_service_commons/api/di.py
+++ b/src/ghga_service_commons/api/di.py
@@ -32,7 +32,7 @@ class DependencyDummy:
 
     def __repr__(self):
         """Return a string representation of the dependency."""
-        return f"DependencyDummy({self.label})"
+        return f"DependencyDummy('{self.label}')"
 
     def __call__(self):
         """Should never be called. If this is called it means that this dummy has not

--- a/src/ghga_service_commons/api/di.py
+++ b/src/ghga_service_commons/api/di.py
@@ -1,0 +1,44 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+"""Utils for dependency injection using FastAPI."""
+
+
+class DependencyDummy:
+    """A placeholder for a dependency that is injected at runtime into a FastAPI app.
+    To be used in view definitions with the fastapi.Depends construct:
+    https://fastapi.tiangolo.com/tutorial/dependencies/
+    """
+
+    def __init__(self, label: str):
+        """Initialize with a label that should describe the dependency that shall be
+        injected.
+        """
+        self.label = label
+
+    def __repr__(self):
+        """Return a string representation of the dependency."""
+        return f"DependencyDummy({self.label})"
+
+    def __call__(self):
+        """Should never be called. If this is called it means that this dummy has not
+        been replaced with the real dependency. An error will be raised.
+        """
+        raise RuntimeError(
+            f"The dependency dummy with label '{self.label}' was not replaced with an"
+            + " actual dependency."
+        )

--- a/src/ghga_service_commons/utils/context.py
+++ b/src/ghga_service_commons/utils/context.py
@@ -1,0 +1,32 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Context manager utils"""
+
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import TypeVar
+
+YieldValue = TypeVar("YieldValue")
+
+
+@asynccontextmanager
+async def asyncnullcontext(
+    yield_value: YieldValue,
+) -> AsyncGenerator[YieldValue, None]:
+    """Async version of contextlib.nullcontext but with a custom yield value."""
+    yield yield_value

--- a/tests/unit/api/test_di.py
+++ b/tests/unit/api/test_di.py
@@ -27,6 +27,11 @@ from ghga_service_commons.api.di import DependencyDummy
 dummy_dependency = DependencyDummy("dummy")
 
 
+def test_dependency_dummy_repr():
+    """Test that the DependencyDummy has a useful repr."""
+    assert repr(dummy_dependency) == "DependencyDummy('dummy')"
+
+
 def test_dependency_dummy_no_override():
     """Test that using a DependencyDummy in a FastAPI app raises an error if it is not
     overridden.

--- a/tests/unit/api/test_di.py
+++ b/tests/unit/api/test_di.py
@@ -1,0 +1,61 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Testing the di utils from the api subpackage."""
+
+from typing import Annotated
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from ghga_service_commons.api.di import DependencyDummy
+
+dummy_dependency = DependencyDummy("dummy")
+
+
+def get_test_app() -> FastAPI:
+    """Get a FastAPI app that uses a DependencyDummy."""
+    app = FastAPI()
+
+    @app.get("/")
+    def get_dummy(dummy: Annotated[str, Depends(dummy_dependency)]):
+        """Dummy view function that uses a DependencyDummy."""
+        return dummy
+
+    return app
+
+
+def test_dependency_dummy_no_override():
+    """Test that using a DependencyDummy in a FastAPI app raises an error if it is not
+    overridden.
+    """
+    app = get_test_app()
+    client = TestClient(app)
+    with pytest.raises(RuntimeError):
+        client.get("/")
+
+
+def test_dependency_dummy_override():
+    """Test that using a DependencyDummy in a FastAPI app does not raise an error if it
+    is overridden.
+    """
+    app = get_test_app()
+    app.dependency_overrides[dummy_dependency] = lambda: "dummy"
+    client = TestClient(app)
+    response = client.get("/")
+
+    assert response.json() == "dummy"

--- a/tests/unit/utils/test_context.py
+++ b/tests/unit/utils/test_context.py
@@ -1,0 +1,30 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Test context utils."""
+
+import pytest
+
+from ghga_service_commons.utils.context import asyncnullcontext
+
+
+@pytest.mark.asyncio
+async def test_asyncnullcontext():
+    """Test the asyncnullcontext context manager."""
+    value = "test"
+
+    async with asyncnullcontext(value) as test:
+        assert test == value


### PR DESCRIPTION
```
- DependencyDummy class for use with FastAPI's Depends
- asyncnullcontext that returns a predefined value upon __enter__

Bumps version to 1.0.0.
```