### PR TITLE
Generation of JSON Schema for Models using DateTimeUTC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghga_service_commons"
-version = "1.0.0"
+version = "1.0.1"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [

--- a/src/ghga_service_commons/utils/utc_dates.py
+++ b/src/ghga_service_commons/utils/utc_dates.py
@@ -52,7 +52,9 @@ class DateTimeUTC(datetime):
         Uses `core_schema.no_info_plain_validator_function` because `cls.validate` is
         the sole validator for `DateTimeUTC`.
         """
-        return core_schema.no_info_plain_validator_function(cls.validate)
+        return core_schema.no_info_after_validator_function(
+            cls.validate, handler(datetime)
+        )
 
     @classmethod
     def validate(cls, value: Any) -> datetime:

--- a/tests/unit/utils/test_utc_dates.py
+++ b/tests/unit/utils/test_utc_dates.py
@@ -119,3 +119,16 @@ def test_now_as_utc():
     assert now_as_utc().tzinfo is UTC
     assert now_as_utc().utcoffset() == timedelta(0)
     assert abs(now_as_utc().timestamp() - datetime.now().timestamp()) < 5
+
+
+def test_datetime_utc_in_pydantic_json_schema():
+    """Test that pydantic can generate a valid json schema for models using
+    DateTimeUTC.
+    """
+
+    class Model(BaseModel):
+        """Test model."""
+
+        test: DateTimeUTC
+
+    Model.model_json_schema()


### PR DESCRIPTION
```
DateTimeUTC now mimics DateTime for schema generation.

Bumps version to 1.0.1.
```