### PR TITLE
Adapt AsyncTestClient and use it internally

### DIFF
--- a/examples/api/tests_api/test_hello_world.py
+++ b/examples/api/tests_api/test_hello_world.py
@@ -16,14 +16,17 @@
 
 """Test the hello world app."""
 
-from fastapi.testclient import TestClient
+import pytest
 from hello_world_web_server.__main__ import app
 
-client = TestClient(app)
+from ghga_service_commons.api.testing import AsyncTestClient
+
+client = AsyncTestClient(app)
 
 
-def test_hello_world():
+@pytest.mark.asyncio
+async def test_hello_world():
     """Test that the hello world app works as expected."""
-    response = client.get("/")
+    response = await client.get("/")
     assert response.status_code == 200
     assert response.json() == "Hello World."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=67.7.2"]
+requires = ["setuptools>=69"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghga_service_commons"
-version = "3.0.3"
+version = "3.0.4"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [

--- a/src/ghga_service_commons/api/testing.py
+++ b/src/ghga_service_commons/api/testing.py
@@ -54,4 +54,6 @@ class AsyncTestClient(httpx.AsyncClient):
 
     def __init__(self, app: Callable[..., Any]):
         """Initialize with ASGI app."""
-        super().__init__(app=app, base_url="http://localhost:8080")
+        super().__init__(
+            transport=httpx.ASGITransport(app=app), base_url="http://localhost:8080"
+        )

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -22,9 +22,9 @@ import time
 import httpx
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 
 from ghga_service_commons.api import ApiConfigBase, run_server
+from ghga_service_commons.api.testing import AsyncTestClient
 from ghga_service_commons.httpyexpect.server import HttpException
 from ghga_service_commons.httpyexpect.server.handlers.fastapi_ import (
     configure_exception_handler,
@@ -58,7 +58,8 @@ async def test_run_server():
     assert response.json() == GREETING
 
 
-def test_configure_exception_handler():
+@pytest.mark.asyncio
+async def test_configure_exception_handler():
     """Test the exception handler configuration of a FastAPI app."""
     # example params for an http exception
     status_code = 400
@@ -72,7 +73,7 @@ def test_configure_exception_handler():
 
     # add a route function that raises an httpyexpect error:
     @app.get("/test")
-    def test_route():
+    async def test_route():
         """A test route function raising an httpyexpect error."""
         raise HttpException(
             status_code=status_code,
@@ -82,8 +83,8 @@ def test_configure_exception_handler():
         )
 
     # send a request using a test client:
-    client = TestClient(app)
-    response = client.get("/test")
+    client = AsyncTestClient(app)
+    response = await client.get("/test")
 
     # check if the response matches the expectation:
     assert response.status_code == status_code

--- a/tests/unit/auth/test_policies.py
+++ b/tests/unit/auth/test_policies.py
@@ -18,10 +18,10 @@
 
 from typing import Optional
 
+import pytest
 from fastapi.exceptions import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
 from pydantic import BaseModel
-from pytest import mark, raises
 from starlette.status import HTTP_403_FORBIDDEN
 
 from ghga_service_commons.auth.context import AuthContextProtocol
@@ -52,7 +52,7 @@ def dummy_predicate(context: DummyAuthContext) -> bool:
     return context.token == "foo"
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_get_auth_context_no_token():
     """Test passing no token to the get_auth_context function."""
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="")
@@ -61,7 +61,7 @@ async def test_get_auth_context_no_token():
     assert context is None
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_get_auth_context_with_token():
     """Test passing a token to the get_auth_context function."""
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="foo")
@@ -71,18 +71,18 @@ async def test_get_auth_context_with_token():
     assert context.token == "foo"
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_require_auth_context_no_token():
     """Test passing no token to the require_auth_context function."""
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="")
     auth_provider = DummyAuthProvider()
-    with raises(HTTPException) as exc_info:
+    with pytest.raises(HTTPException) as exc_info:
         await require_auth_context_using_credentials(credentials, auth_provider)
     assert exc_info.value.status_code == HTTP_403_FORBIDDEN
     assert exc_info.value.detail == "Not authenticated"
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_require_auth_context_with_token():
     """Test passing a token to the require_auth_context function."""
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="foo")
@@ -92,7 +92,7 @@ async def test_require_auth_context_with_token():
     assert context.token == "foo"
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_require_auth_context_with_happy_predicate():
     """Test the happy path of the require_auth_context function with a predicate."""
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="foo")
@@ -104,12 +104,12 @@ async def test_require_auth_context_with_happy_predicate():
     assert context.token == "foo"
 
 
-@mark.asyncio
+@pytest.mark.asyncio
 async def test_require_auth_context_with_unhappy_predicate():
     """Test the unhappy path of the require_auth_context function with a predicate."""
     credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="bar")
     auth_provider = DummyAuthProvider()
-    with raises(HTTPException) as exc_info:
+    with pytest.raises(HTTPException) as exc_info:
         await require_auth_context_using_credentials(
             credentials, auth_provider, dummy_predicate
         )

--- a/tests/unit/utils/test_utc_dates.py
+++ b/tests/unit/utils/test_utc_dates.py
@@ -18,8 +18,8 @@
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
+import pytest
 from pydantic import BaseModel
-from pytest import mark, raises
 
 from ghga_service_commons.utils.utc_dates import (
     UTC,
@@ -29,7 +29,7 @@ from ghga_service_commons.utils.utc_dates import (
 )
 
 
-@mark.parametrize(
+@pytest.mark.parametrize(
     "value",
     [
         "2022-11-15 12:00:00",
@@ -48,11 +48,11 @@ def test_does_not_accept_naive_datetimes(value):
 
         d: UTCDatetime
 
-    with raises(ValueError):
+    with pytest.raises(ValueError):
         Model(d=value)
 
 
-@mark.parametrize(
+@pytest.mark.parametrize(
     "value",
     [
         "2022-11-15T12:00:00+00:00",
@@ -76,7 +76,7 @@ def test_accept_aware_datetimes_in_utc(value):
     assert model.dt == model.du
 
 
-@mark.parametrize(
+@pytest.mark.parametrize(
     "value",
     [
         "2022-11-15T12:00:00+03:00",


### PR DESCRIPTION
- Adapt AsyncTestClient to latest httpx (app parameter was deprecated)
- Use our own AsyncTestClient instead of default TestClient internally (eat your own dogfoot)