### PR TITLE
Fix publishing on PyPI

### DIFF
--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
@@ -19,7 +19,7 @@ jobs:
 
       - name: Verify Package Version vs Tag Version
         run: |
-          PKG_VER="$(grep -oP 'version = "\K[^"]+' pyproject.toml)"
+          PKG_VER="$(grep -oP '^version = "\K[^"]+' pyproject.toml)"
           TAG_VER="${GITHUB_REF##*/}"
           echo "Package version is $PKG_VER" >&2
           echo "Tag version is $TAG_VER" >&2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ghga_service_commons"
-version = "3.0.4"
+version = "3.0.3"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [

--- a/src/ghga_service_commons/api/testing.py
+++ b/src/ghga_service_commons/api/testing.py
@@ -17,7 +17,7 @@
 """Functionality for testing FastAPI-based APIs."""
 
 import socket
-from typing import Any, Callable
+from typing import Any, Callable, Generic, TypeVar
 
 import httpx
 
@@ -29,7 +29,10 @@ def get_free_port() -> int:
     return int(sock.getsockname()[1])
 
 
-class AsyncTestClient(httpx.AsyncClient):
+TApp = TypeVar("TApp", bound=Callable[..., Any])
+
+
+class AsyncTestClient(httpx.AsyncClient, Generic[TApp]):
     """Client for testing ASGI apps in the context of a running async event loop.
 
     Usage: ```
@@ -52,8 +55,11 @@ class AsyncTestClient(httpx.AsyncClient):
     ```
     """
 
-    def __init__(self, app: Callable[..., Any]):
+    app: TApp
+
+    def __init__(self, app: TApp):
         """Initialize with ASGI app."""
+        self.app = app  # make the application available to tests as well
         super().__init__(
             transport=httpx.ASGITransport(app=app), base_url="http://localhost:8080"
         )


### PR DESCRIPTION
The GitHub action was broken after the pyproject.toml contained more version fields.

Also improve AsyncTestClient by making the app available again as an attribute.