### PR TITLE
Feature/x request id gsi 681

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_service_commons"
-version = "3.1.0"
+version = "3.1.1"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_service_commons"
-version = "3.1.0"
+version = "3.1.1"
 description = "A library that contains common functionality used in services of GHGA"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/ghga_service_commons/api/api.py
+++ b/src/ghga_service_commons/api/api.py
@@ -42,7 +42,9 @@ from ghga_service_commons.httpyexpect.server.handlers.fastapi_ import (
     configure_exception_handler,
 )
 
-CORRELATION_ID_HEADER_NAME = "X-Request-Id"  # As set by emissary-ingress
+# unofficial, but frequently used header name
+# that is also used by Envoy-based proxies like Emissary-ingress
+CORRELATION_ID_HEADER_NAME = "X-Request-Id"
 
 
 log = logging.getLogger(__name__)

--- a/src/ghga_service_commons/api/api.py
+++ b/src/ghga_service_commons/api/api.py
@@ -42,7 +42,7 @@ from ghga_service_commons.httpyexpect.server.handlers.fastapi_ import (
     configure_exception_handler,
 )
 
-CORRELATION_ID_HEADER_NAME = "X-Correlation-ID"
+CORRELATION_ID_HEADER_NAME = "X-Request-Id"  # As set by emissary-ingress
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
This PR changes the name of the internally-used correlation ID header to "X-Request-Id". This is because the Emissary-ingress gateway already supplies requests with an X-Request-Id header that holds a UUID4 (the same as what we used for the correlation ID). By generating a separate x-correlation-id, we were inadvertently performing unnecessary work. Changing the name of the header should have no downstream impact.