### PR TITLE
Install secondary Python in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,12 +7,23 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID vscode && usermod --uid $USER_UID --gid $USER_GID vscode; fi
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
-
-# Copy install and launcher script to bin:
+# Copy install and launcher script
 COPY ./dev_install /bin
+
+# Install secondary Python version
+USER vscode
+RUN <<EOF
+curl -sS https://pyenv.run | /bin/sh
+INIT_PYENV='
+export PYENV_ROOT="$HOME/.pyenv"
+[ -d "$PYENV_ROOT/bin" ] && export PATH="$PYENV_ROOT/bin:$PATH"
+eval "$(pyenv init -)"
+'
+echo "$INIT_PYENV" >> ~/.profile
+echo "$INIT_PYENV" >> ~/.bashrc
+. ~/.profile
+pyenv install --skip-existing 3.12
+pyenv global system 3.12
+EOF
 
 CMD ["sleep", "infinity"]

--- a/.devcontainer/dev_install
+++ b/.devcontainer/dev_install
@@ -3,23 +3,6 @@
 
 cd /workspace
 
-# install secondary Python version
-if ! [ -d "$HOME/.pyenv" ]
-then
-    curl -sS https://pyenv.run | /bin/sh
-    LOAD_PATH_INSTRUCTIONS='''
-export PYENV_ROOT="$HOME/.pyenv"
-[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init -)"
-'''
-    echo "$LOAD_PATH_INSTRUCTIONS" >> ~/.profile
-    echo "$LOAD_PATH_INSTRUCTIONS" >> ~/.bashrc
-    source ~/.profile
-    source ~/.bashrc
-fi
-pyenv install --skip-existing 3.12
-pyenv global system 3.12
-
 # upgrade pip
 python -m pip install --upgrade pip
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   ghga_service_commons:
     build:

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   pypi-publish:
-    runs-on: ubuntu-latest
-
     name: Publish tagged release on PyPI
+
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   static-code-analysis:
-    runs-on: ubuntu-latest
-
     name: Static Code Analysis
+
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Install the secondary Python version already in the Dockerfile, not in dev_install.

This avoids accidentally installing it twice, or not finding pyenv because the changed bashrc has not been reloaded.