### PR TITLE
Fix typo in api export and remove pylint pragmas

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_service_commons"
-version = "3.1.4"
+version = "3.1.5"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [

--- a/examples/api/hello_world_web_server/__main__.py
+++ b/examples/api/hello_world_web_server/__main__.py
@@ -20,7 +20,7 @@ import asyncio
 from ghga_service_commons.api import run_server
 from ghga_service_commons.utils.utc_dates import assert_tz_is_utc
 
-from .api import app  # noqa: F401 pylint: disable=unused-import
+from .api import app  # noqa: F401
 from .config import get_config
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_service_commons"
-version = "3.1.4"
+version = "3.1.5"
 description = "A library that contains common functionality used in services of GHGA"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/ghga_service_commons/api/__init__.py
+++ b/src/ghga_service_commons/api/__init__.py
@@ -17,10 +17,10 @@
 
 """Functionality building HTTP APIs using FastAPI."""
 
-from ghga_service_commons.api.api import (  # noqa: F401
+from ghga_service_commons.api.api import (
     ApiConfigBase,
     configure_app,
     run_server,
 )
 
-__all__ = ["ApiCOnfigBase", "configure_app", "run_server"]
+__all__ = ["ApiConfigBase", "configure_app", "run_server"]

--- a/src/ghga_service_commons/httpyexpect/server/handlers/fastapi_.py
+++ b/src/ghga_service_commons/httpyexpect/server/handlers/fastapi_.py
@@ -33,7 +33,7 @@ def configure_exception_handler(app: FastAPI) -> None:
 
     @app.exception_handler(HttpException)
     def exception_handler(
-        request: Request,  # pylint: disable=unused-argument
+        request: Request,
         # (The above is required by the corresponding FastAPI interface but not used here)
         exc: HttpException,
     ) -> JSONResponse:

--- a/tests/integration/test_httpyexpect_client.py
+++ b/tests/integration/test_httpyexpect_client.py
@@ -105,7 +105,6 @@ def test_typical_client_usage(
 
 def test_compatibility_with_httpx():
     """Make sure that our Response protocol is compatible with the httpx library."""
-    # pylint: disable=import-outside-toplevel
     from httpx import Response as HttpxResponse
 
     httpx_response = HttpxResponse(status_code=200, content=b'{"hello": "world"}')
@@ -116,7 +115,6 @@ def test_compatibility_with_httpx():
 
 def test_compatibility_with_requests():
     """Make sure that our Response protocol is compatible with the requests library."""
-    # pylint: disable=import-outside-toplevel
     from requests import Response as RequestsResponse
 
     requests_response = RequestsResponse()


### PR DESCRIPTION
There was a typo in .api where `ApiConfigBase` was instead exported as `ApiCOnfigBase`, which angered the static analyzer.
Bumps patch number