### PR TITLE
Trim root path

### DIFF
--- a/src/ghga_service_commons/api/api.py
+++ b/src/ghga_service_commons/api/api.py
@@ -219,7 +219,7 @@ async def correlation_id_middleware(
 
 def configure_app(app: FastAPI, config: ApiConfigBase):
     """Configure a FastAPI app based on a config object."""
-    app.root_path = config.api_root_path
+    app.root_path = config.api_root_path.rstrip("/")
     app.openapi_url = config.openapi_url
     app.docs_url = config.docs_url
 


### PR DESCRIPTION
The `api_root_path` is passed to the FastAPI application as `root_path`. This ASGI feature corresponds to `WSGI_SCRIPT` in WSGI. The value should always exclude the trailing slash, particularly intstead of "/" the root path should be "", which is the default value. Since an accidentally added trailing slash leads to problems which are hard to debug, we trim any trailing slahes here before passing the value to FastAPI.