### PR TITLE
Roll back the pytest-httpx version bump

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_service_commons"
-version = "3.1.6"
+version = "3.1.7"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [

--- a/lock/requirements-dev.txt
+++ b/lock/requirements-dev.txt
@@ -687,9 +687,9 @@ pytest-cov==6.0.0 \
     --hash=sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35 \
     --hash=sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0
     # via -r lock/requirements-dev-template.in
-pytest-httpx==0.33.0 \
-    --hash=sha256:4af9ab0dae5e9c14cb1e27d18af3db1f627b2cf3b11c02b34ddf26aff6b0a24c \
-    --hash=sha256:bdd1b00a846cfe857194e4d3ba72dc08ba0d163154a4404269c9b971f357c05d
+pytest-httpx==0.30.0 \
+    --hash=sha256:6d47849691faf11d2532565d0c8e0e02b9f4ee730da31687feae315581d7520c \
+    --hash=sha256:755b8edca87c974dd4f3605c374fda11db84631de3d163b99c0df5807023a19a
     # via -r lock/requirements-dev-template.in
 python-dotenv==1.0.1 \
     --hash=sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_service_commons"
-version = "3.1.6"
+version = "3.1.7"
 description = "A library that contains common functionality used in services of GHGA"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/ghga_service_commons/api/mock_router.py
+++ b/src/ghga_service_commons/api/mock_router.py
@@ -23,11 +23,16 @@ from inspect import signature
 from typing import Any, Callable, Generic, TypeVar, cast, get_type_hints
 
 import httpx
+import pytest
 from pydantic import BaseModel
 
 from ghga_service_commons.httpyexpect.server.exceptions import HttpException
 
-__all__ = ["MockRouter", "HttpException"]
+__all__ = [
+    "MockRouter",
+    "assert_all_responses_were_requested",
+    "HttpException",
+]
 
 BRACKET_PATTERN = re.compile(r"{.*?}")
 
@@ -60,6 +65,16 @@ def _get_signature_info(endpoint_function: Callable) -> dict[str, Any]:
     if "return" in signature_parameters:
         signature_parameters.pop("return")
     return signature_parameters
+
+
+@pytest.fixture
+def assert_all_responses_were_requested() -> bool:
+    """Whether httpx checks that all registered responses are sent back.
+    This is set to false because the registered endpoints are considered mocked even if
+    they aren't used in a given test. If this is True (default), pytest_httpx will raise
+    an error if a given test doesn't hit every mocked endpoint.
+    """
+    return False
 
 
 class RegisteredEndpoint(BaseModel):

--- a/tests/integration/test_mock_router.py
+++ b/tests/integration/test_mock_router.py
@@ -23,7 +23,10 @@ import pytest
 from fastapi import HTTPException
 from pytest_httpx import HTTPXMock, httpx_mock  # noqa: F401
 
-from ghga_service_commons.api.mock_router import MockRouter
+from ghga_service_commons.api.mock_router import (  # noqa: F401
+    MockRouter,
+    assert_all_responses_were_requested,
+)
 from ghga_service_commons.httpyexpect.server.exceptions import HttpException
 from tests.integration.fixtures.mock_api import app
 
@@ -184,9 +187,6 @@ def test_endpoint_missing_typehint():
             """Define a dummy function with missing type-hint info."""
 
 
-@pytest.mark.httpx_mock(
-    assert_all_responses_were_requested=False, can_send_already_matched_responses=True
-)
 def test_handler_errors_filtering(httpx_mock: HTTPXMock):  # noqa: F811
     """Make sure only the specified errors are passed to the handler.
 


### PR DESCRIPTION
Bumps version from 3.1.6 to 3.1.7

When updating the FastAPI/starlette dependencies in 3.1.6, the pytest-httpx version was also bumped. This created a change for one of the test utils provided by ghga-service-commons, which was small but breaking. The pytest-httpx version bump should not have been performed, so this PR rolls the change back.