### PR TITLE
Propagate Correlation ID (GSI-1225)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_service_commons"
-version = "3.1.8"
+version = "3.2.0"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [
@@ -12,14 +12,17 @@ dependencies = ["pydantic >=2, <3"]
 api = [
     "fastapi>=0.115.3, <0.116",
     "uvicorn[standard]>=0.29, <0.30",
-    "ghga-service-commons[objectstorage]",
+    "ghga-service-commons[http,objectstorage]",
+]
+http = [
+    "httpx>=0.27, < 0.28",
 ]
 auth = ["jwcrypto>=1.5.6, <2", "pydantic[email]>=2, <3"]
 crypt = ["pynacl>=1.5, <2", "crypt4gh>=1.6, <2"]
 dev = ["requests>=2.31, <3"]
 objectstorage = ["hexkit>=2, <4"]
 
-all = ["ghga-service-commons[api,auth,crypt,dev,objectstorage]"]
+all = ["ghga-service-commons[api,auth,crypt,dev,http,objectstorage]"]
 
 [project.license]
 text = "Apache 2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_service_commons"
-version = "3.1.8"
+version = "3.2.0"
 description = "A library that contains common functionality used in services of GHGA"
 dependencies = [
     "pydantic >=2, <3",
@@ -36,7 +36,10 @@ text = "Apache 2.0"
 api = [
     "fastapi>=0.115.3, <0.116",
     "uvicorn[standard]>=0.29, <0.30",
-    "ghga-service-commons[objectstorage]",
+    "ghga-service-commons[http,objectstorage]",
+]
+http = [
+    "httpx>=0.27, < 0.28",
 ]
 auth = [
     "jwcrypto>=1.5.6, <2",
@@ -53,7 +56,7 @@ objectstorage = [
     "hexkit>=2, <4",
 ]
 all = [
-    "ghga-service-commons[api,auth,crypt,dev,objectstorage]",
+    "ghga-service-commons[api,auth,crypt,dev,http,objectstorage]",
 ]
 
 [project.urls]

--- a/src/ghga_service_commons/http/__init__.py
+++ b/src/ghga_service_commons/http/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for outbound HTTP calls"""

--- a/src/ghga_service_commons/http/correlation.py
+++ b/src/ghga_service_commons/http/correlation.py
@@ -1,0 +1,76 @@
+# Copyright 2021 - 2024 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tools to enhance traceability of HTTP requests across microservices."""
+
+import logging
+from functools import partial
+from typing import Union
+
+import httpx
+from hexkit.correlation import (
+    CorrelationIdContextError,
+    get_correlation_id,
+    new_correlation_id,
+)
+
+CORRELATION_ID_HEADER_NAME = "X-Request-Id"
+log = logging.getLogger(__name__)
+
+
+def add_correlation_id_to_request(request, generate_correlation_id: bool):
+    """Include the correlation ID in the request header so it is propagated.
+
+    If the correlation ID isn't set, one will be generated if `generate_correlation_id`
+    is set. Otherwise, an error will be raised.
+
+    Raises:
+        CorrelationIdContextError: when the correlation ID ContextVar is not set.
+        InvalidCorrelationIdError: when the correlation ID is invalid.
+    """
+    try:
+        correlation_id = get_correlation_id()
+    except CorrelationIdContextError:
+        if generate_correlation_id:
+            correlation_id = new_correlation_id()
+        else:
+            raise
+    request.headers[CORRELATION_ID_HEADER_NAME] = correlation_id
+
+
+async def add_correlation_id_to_request_async(request, generate_correlation_id: bool):
+    """Async version of `add_correlation_id_to_request`"""
+    add_correlation_id_to_request(request, generate_correlation_id)
+
+
+def attach_correlation_id_to_requests(
+    client: Union[httpx.Client, httpx.AsyncClient],
+    *,
+    generate_correlation_id: bool,
+):
+    """Add an event hook to an httpx Client that includes the correlation ID header."""
+    if "request" not in client.event_hooks:
+        client.event_hooks["request"] = []
+
+    event_hook = partial(
+        add_correlation_id_to_request,
+        generate_correlation_id=generate_correlation_id,
+    )
+
+    if isinstance(client, httpx.AsyncClient):
+        event_hook = partial(
+            add_correlation_id_to_request_async,
+            generate_correlation_id=generate_correlation_id,
+        )
+    client.event_hooks["request"].append(event_hook)

--- a/src/ghga_service_commons/http/correlation.py
+++ b/src/ghga_service_commons/http/correlation.py
@@ -60,17 +60,9 @@ def attach_correlation_id_to_requests(
     generate_correlation_id: bool,
 ):
     """Add an event hook to an httpx Client that includes the correlation ID header."""
-    if "request" not in client.event_hooks:
-        client.event_hooks["request"] = []
-
+    is_async = isinstance(client, httpx.AsyncClient)
     event_hook = partial(
-        _cid_request_hook,
+        _cid_request_hook_async if is_asycnc else _cid_request_hook,
         generate_correlation_id=generate_correlation_id,
     )
-
-    if isinstance(client, httpx.AsyncClient):
-        event_hook = partial(
-            _cid_request_hook_async,
-            generate_correlation_id=generate_correlation_id,
-        )
-    client.event_hooks["request"].append(event_hook)
+    client.event_hooks.setdefault("request", []).append(event_hook)

--- a/src/ghga_service_commons/http/correlation.py
+++ b/src/ghga_service_commons/http/correlation.py
@@ -57,12 +57,12 @@ async def _cid_request_hook_async(request, generate_correlation_id: bool):
 def attach_correlation_id_to_requests(
     client: Union[httpx.Client, httpx.AsyncClient],
     *,
-    generate_correlation_id: bool,
+    generate_correlation_id: bool = True,
 ):
     """Add an event hook to an httpx Client that includes the correlation ID header."""
     is_async = isinstance(client, httpx.AsyncClient)
     event_hook = partial(
-        _cid_request_hook_async if is_asycnc else _cid_request_hook,
+        _cid_request_hook_async if is_async else _cid_request_hook,
         generate_correlation_id=generate_correlation_id,
     )
     client.event_hooks.setdefault("request", []).append(event_hook)

--- a/src/ghga_service_commons/http/correlation.py
+++ b/src/ghga_service_commons/http/correlation.py
@@ -59,3 +59,15 @@ def attach_correlation_id_to_requests(
         generate_correlation_id=generate_correlation_id,
     )
     client.event_hooks.setdefault("request", []).append(event_hook)
+
+
+class AsyncClient(httpx.AsyncClient):
+    """A version of httpx.AsyncClient that always attaches the correlation ID header.
+
+    If no correlation ID is found in the current context, a new one will be generated.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        event_hook = partial(_cid_request_hook, generate_correlation_id=True)
+        self.event_hooks.setdefault("request", []).append(event_hook)

--- a/src/ghga_service_commons/http/correlation.py
+++ b/src/ghga_service_commons/http/correlation.py
@@ -25,7 +25,7 @@ from hexkit.correlation import (
 
 CORRELATION_ID_HEADER_NAME = "X-Request-Id"
 
-__all__ = ["attach_correlation_id_to_requests"]
+__all__ = ["attach_correlation_id_to_requests", "AsyncClient"]
 
 
 async def _cid_request_hook(request, generate_correlation_id: bool):

--- a/src/ghga_service_commons/http/correlation.py
+++ b/src/ghga_service_commons/http/correlation.py
@@ -62,12 +62,15 @@ def attach_correlation_id_to_requests(
 
 
 class AsyncClient(httpx.AsyncClient):
-    """A version of httpx.AsyncClient that always attaches the correlation ID header.
+    """A version of httpx.AsyncClient that attaches the correlation ID header in requests.
 
-    If no correlation ID is found in the current context, a new one will be generated.
+    If no correlation ID is found in the current context, a new one will be generated
+    OR an error will be raised based on the value of `generate_correlation_id`.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, generate_correlation_id: bool = True, **kwargs):
         super().__init__(*args, **kwargs)
-        event_hook = partial(_cid_request_hook, generate_correlation_id=True)
+        event_hook = partial(
+            _cid_request_hook, generate_correlation_id=generate_correlation_id
+        )
         self.event_hooks.setdefault("request", []).append(event_hook)

--- a/src/ghga_service_commons/http/correlation.py
+++ b/src/ghga_service_commons/http/correlation.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Tools to enhance traceability of HTTP requests across microservices."""
 
-import logging
 from functools import partial
 from typing import Union
 
@@ -26,7 +25,6 @@ from hexkit.correlation import (
 )
 
 CORRELATION_ID_HEADER_NAME = "X-Request-Id"
-log = logging.getLogger(__name__)
 
 
 def add_correlation_id_to_request(request, generate_correlation_id: bool):

--- a/src/ghga_service_commons/http/correlation.py
+++ b/src/ghga_service_commons/http/correlation.py
@@ -15,7 +15,6 @@
 """Tools to enhance traceability of HTTP requests across microservices."""
 
 from functools import partial
-from typing import Union
 
 import httpx
 from hexkit.correlation import (
@@ -29,7 +28,7 @@ CORRELATION_ID_HEADER_NAME = "X-Request-Id"
 __all__ = ["attach_correlation_id_to_requests"]
 
 
-def _cid_request_hook(request, generate_correlation_id: bool):
+async def _cid_request_hook(request, generate_correlation_id: bool):
     """Include the correlation ID in the request header so it is propagated.
 
     If the correlation ID isn't set, one will be generated if `generate_correlation_id`
@@ -49,20 +48,14 @@ def _cid_request_hook(request, generate_correlation_id: bool):
     request.headers[CORRELATION_ID_HEADER_NAME] = correlation_id
 
 
-async def _cid_request_hook_async(request, generate_correlation_id: bool):
-    """Async version of `_cid_request_hook`"""
-    _cid_request_hook(request, generate_correlation_id)
-
-
 def attach_correlation_id_to_requests(
-    client: Union[httpx.Client, httpx.AsyncClient],
+    client: httpx.AsyncClient,
     *,
     generate_correlation_id: bool = True,
 ):
     """Add an event hook to an httpx Client that includes the correlation ID header."""
-    is_async = isinstance(client, httpx.AsyncClient)
     event_hook = partial(
-        _cid_request_hook_async if is_async else _cid_request_hook,
+        _cid_request_hook,
         generate_correlation_id=generate_correlation_id,
     )
     client.event_hooks.setdefault("request", []).append(event_hook)

--- a/src/ghga_service_commons/http/correlation.py
+++ b/src/ghga_service_commons/http/correlation.py
@@ -26,8 +26,10 @@ from hexkit.correlation import (
 
 CORRELATION_ID_HEADER_NAME = "X-Request-Id"
 
+__all__ = ["attach_correlation_id_to_requests"]
 
-def add_correlation_id_to_request(request, generate_correlation_id: bool):
+
+def _cid_request_hook(request, generate_correlation_id: bool):
     """Include the correlation ID in the request header so it is propagated.
 
     If the correlation ID isn't set, one will be generated if `generate_correlation_id`
@@ -47,9 +49,9 @@ def add_correlation_id_to_request(request, generate_correlation_id: bool):
     request.headers[CORRELATION_ID_HEADER_NAME] = correlation_id
 
 
-async def add_correlation_id_to_request_async(request, generate_correlation_id: bool):
-    """Async version of `add_correlation_id_to_request`"""
-    add_correlation_id_to_request(request, generate_correlation_id)
+async def _cid_request_hook_async(request, generate_correlation_id: bool):
+    """Async version of `_cid_request_hook`"""
+    _cid_request_hook(request, generate_correlation_id)
 
 
 def attach_correlation_id_to_requests(
@@ -62,13 +64,13 @@ def attach_correlation_id_to_requests(
         client.event_hooks["request"] = []
 
     event_hook = partial(
-        add_correlation_id_to_request,
+        _cid_request_hook,
         generate_correlation_id=generate_correlation_id,
     )
 
     if isinstance(client, httpx.AsyncClient):
         event_hook = partial(
-            add_correlation_id_to_request_async,
+            _cid_request_hook_async,
             generate_correlation_id=generate_correlation_id,
         )
     client.event_hooks["request"].append(event_hook)


### PR DESCRIPTION
Adds a subpackage `ghga_service_commons.http`, which contains a function called `attach_correlation_id_to_requests`.

If you only want to use this aspect of HTTP functionality and don't need the API module, then you can specify `ghga-service-commons[http]` in your service's dependency list. 

The intent is that you call `attach_correlation_id_to_requests` on an instance of `httpx.Client` or `httpx.AsyncClient`, and it will add an [event hook](https://www.python-httpx.org/advanced/event-hooks/) that ensures outbound requests contain the correlation ID in the headers.

I updated the correlation ID middleware function so it packs the correlation ID in the _response_ headers too for continuity. It will raise a new error class, `UnexpectedCorrelationIdError`, if the response contains an unexpected CID value already.

This PR bumps the version to `3.2.0` because of the new backwards-compatible feature.