### PR TITLE
Avoid duplicate traceback (GSI-1473)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_service_commons"
-version = "3.4.0"
+version = "3.4.1"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [

--- a/examples/api/.hello_world.yaml
+++ b/examples/api/.hello_world.yaml
@@ -1,6 +1,5 @@
 host: 127.0.0.1
 port: 8080
-log_level: info
 greeting: World
 cors_allowed_origins: ["*"]
 cors_allow_credentials: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_service_commons"
-version = "3.4.0"
+version = "3.4.1"
 description = "A library that contains common functionality used in services of GHGA"
 dependencies = [
     "pydantic >=2, <3",


### PR DESCRIPTION
When a REST API endpoint raises an unhandled exception, the resulting error log would look like this:

```
ERROR:    Exception in ASGI application
  + Exception Group Traceback (most recent call last):
  |   File "/home/vscode/.local/lib/python3.12/site-packages/starlette/_utils.py", line 76, in collapse_excgroups
  |     yield
  |   File "/home/vscode/.local/lib/python3.12/site-packages/starlette/middleware/base.py", line 174, in __call__
  |     async with anyio.create_task_group() as task_group:
  |                ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/home/vscode/.local/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 767, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/home/vscode/.local/lib/python3.12/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
    |     result = await app(  # type: ignore[func-returns-value]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |  ...
    |   File "/workspace/examples/api/hello_world_web_server/api.py", line 28, in hello
    |     return "Hello World" + {"a": "b"}["c"]
    |                            ~~~~~~~~~~^^^^^
    | KeyError: 'c'
    +------------------------------------

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/vscode/.local/lib/python3.12/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ...
  File "/workspace/examples/api/hello_world_web_server/api.py", line 28, in hello
    return "Hello World" + {"a": "b"}["c"]
                           ~~~~~~~~~~^^^^^
KeyError: 'c'
```

Obviously, the error including the complete traceback is repeated which causes bloat in the logs files and makes it look like multiple errors happened.

This problem does not exist with a normal FastAPI app using uvicorn, it only appears when using the ghga-service-commons api utils.

After some debugging I found that it is caused by our two custom HTTP middlewares which have been built using `BaseHTTPMiddleware`. With pure ASGI middlewares, this problem does not exist. There was also some discussion about deprecating `BaseHTTPMiddleware`. Therefore I decided to rewrite our two middlewares as pure ASGI middewares.

The PR also fixes and issue with the example REST application - the log level is not part of the default config any more, but it was set in the yaml config.





