### PR TITLE
Switch to hexkit v6 (GSI-1712)

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_service_commons"
-version = "4.1.1"
+version = "4.2.0"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [
@@ -20,7 +20,7 @@ http = [
 auth = ["jwcrypto>=1.5.6, <2", "pydantic[email]>=2, <3"]
 crypt = ["pynacl>=1.5, <2", "crypt4gh>=1.6, <2"]
 dev = ["requests>=2.31, <3"]
-objectstorage = ["hexkit>=2, <6"]
+objectstorage = ["hexkit>=7"]
 
 all = ["ghga-service-commons[api,auth,crypt,dev,http,objectstorage]"]
 

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_service_commons"
-version = "4.2.0"
+version = "5.0.0"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -20,7 +20,7 @@ http = [
 auth = ["jwcrypto>=1.5.6, <2", "pydantic[email]>=2, <3"]
 crypt = ["pynacl>=1.5, <2", "crypt4gh>=1.6, <2"]
 dev = ["requests>=2.31, <3"]
-objectstorage = ["hexkit>=7"]
+objectstorage = ["hexkit>=6"]
 
 all = ["ghga-service-commons[api,auth,crypt,dev,http,objectstorage]"]
 

--- a/lock/requirements-dev.txt
+++ b/lock/requirements-dev.txt
@@ -406,9 +406,9 @@ h11==0.16.0 \
     # via
     #   httpcore
     #   uvicorn
-hexkit==5.4.1 \
-    --hash=sha256:6879fd265e891cd5f3bfd1d86e3f75f15e4ec9b6e85d4cd121dc73d9bd84dddd \
-    --hash=sha256:dda609b31300cd2aedaf873d456c2159c6489ded8f7ba74b6e6cc07f9a1b8e33
+hexkit==6.0.0 \
+    --hash=sha256:021ffd92559468860bd744daeb32cd7428f58395eade416d4b1b103258cc6414 \
+    --hash=sha256:a1af45ad5325a64050de4ac9e9ced3ac30a32db1b9cef5fa208b49630322dc1e
     # via ghga-service-commons (pyproject.toml)
 httpcore==1.0.9 \
     --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \

--- a/lock/requirements.txt
+++ b/lock/requirements.txt
@@ -327,9 +327,9 @@ h11==0.16.0 \
     #   -c lock/requirements-dev.txt
     #   httpcore
     #   uvicorn
-hexkit==5.4.1 \
-    --hash=sha256:6879fd265e891cd5f3bfd1d86e3f75f15e4ec9b6e85d4cd121dc73d9bd84dddd \
-    --hash=sha256:dda609b31300cd2aedaf873d456c2159c6489ded8f7ba74b6e6cc07f9a1b8e33
+hexkit==6.0.0 \
+    --hash=sha256:021ffd92559468860bd744daeb32cd7428f58395eade416d4b1b103258cc6414 \
+    --hash=sha256:a1af45ad5325a64050de4ac9e9ced3ac30a32db1b9cef5fa208b49630322dc1e
     # via
     #   -c lock/requirements-dev.txt
     #   ghga-service-commons (pyproject.toml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_service_commons"
-version = "4.1.1"
+version = "4.2.0"
 description = "A library that contains common functionality used in services of GHGA"
 dependencies = [
     "pydantic >=2, <3",
@@ -53,7 +53,7 @@ dev = [
     "requests>=2.31, <3",
 ]
 objectstorage = [
-    "hexkit>=2, <6",
+    "hexkit>=2, <7",
 ]
 all = [
     "ghga-service-commons[api,auth,crypt,dev,http,objectstorage]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
     "requests>=2.31, <3",
 ]
 objectstorage = [
-    "hexkit>=2, <7",
+    "hexkit>=6",
 ]
 all = [
     "ghga-service-commons[api,auth,crypt,dev,http,objectstorage]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_service_commons"
-version = "4.2.0"
+version = "5.0.0"
 description = "A library that contains common functionality used in services of GHGA"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/ghga_service_commons/api/api.py
+++ b/src/ghga_service_commons/api/api.py
@@ -365,7 +365,7 @@ def configure_app(app: FastAPI, config: ApiConfigBase):
 
     app.add_middleware(RequestLoggingMiddleware)
     app.add_middleware(CorrelationIdMiddleware, config.generate_correlation_id)
-    app.add_middleware(CORSMiddleware, **kwargs)
+    app.add_middleware(CORSMiddleware, **kwargs)  # type: ignore[arg-type]
 
     # Configure the exception handler to issue error according to httpyexpect model:
     configure_exception_handler(app)

--- a/src/ghga_service_commons/api/api.py
+++ b/src/ghga_service_commons/api/api.py
@@ -31,11 +31,12 @@ from fastapi import FastAPI, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from hexkit.correlation import (
     InvalidCorrelationIdError,
+    correlation_id_from_str,
     new_correlation_id,
     set_correlation_id,
     validate_correlation_id,
 )
-from pydantic import Field
+from pydantic import UUID4, Field
 from pydantic_settings import BaseSettings
 
 from ghga_service_commons.httpyexpect.models import HttpExceptionBody
@@ -164,10 +165,10 @@ class ApiConfigBase(BaseSettings):
     )
 
 
-def set_header_correlation_id(request: Request, correlation_id: str):
+def set_header_correlation_id(request: Request, correlation_id: UUID4):
     """Set the correlation ID on the request header. Modifies the header in-place."""
     headers = request.headers.mutablecopy()
-    headers[CORRELATION_ID_HEADER_NAME] = correlation_id
+    headers[CORRELATION_ID_HEADER_NAME] = str(correlation_id)
     request.scope.update(headers=headers.raw)
     # delete _headers to force update
     delattr(request, "_headers")
@@ -176,7 +177,7 @@ def set_header_correlation_id(request: Request, correlation_id: str):
 
 def get_validated_correlation_id(
     correlation_id: str, generate_correlation_id: bool
-) -> str:
+) -> UUID4:
     """Returns valid correlation ID.
 
     If `correlation_id` is valid, it returns that.
@@ -184,15 +185,16 @@ def get_validated_correlation_id(
     Otherwise, an error is raised.
 
     Raises:
-        InvalidCorrelationIdError: If a correlation ID is invalid or empty (and
+        InvalidCorrelationIdError: If a correlation ID is invalid (and
             `generate_correlation_id` is False).
     """
     if not correlation_id and generate_correlation_id:
-        correlation_id = new_correlation_id()
+        valid_correlation_id = new_correlation_id()
         log.debug("Generated new correlation id: %s", correlation_id)
     else:
-        validate_correlation_id(correlation_id)
-    return correlation_id
+        valid_correlation_id = correlation_id_from_str(correlation_id)
+        validate_correlation_id(valid_correlation_id)
+    return valid_correlation_id
 
 
 class UnexpectedCorrelationIdError(RuntimeError):
@@ -234,13 +236,13 @@ class CorrelationIdMiddleware:
         request = Request(scope)
         headers = request.headers
 
-        correlation_id = headers.get(CORRELATION_ID_HEADER_NAME, "")
+        correlation_id_from_headers = headers.get(CORRELATION_ID_HEADER_NAME, "")
 
         # Validate the correlation ID.
         # If validation fails, create a response with bad request status.
         try:
             validated_correlation_id = get_validated_correlation_id(
-                correlation_id, self.generate_correlation_id
+                correlation_id_from_headers, self.generate_correlation_id
             )
         except InvalidCorrelationIdError as error:
             # report the plain error without any traceback
@@ -266,7 +268,7 @@ class CorrelationIdMiddleware:
             return
 
         # Update header if the validated value differs
-        if validated_correlation_id != correlation_id:
+        if str(validated_correlation_id) != correlation_id_from_headers:
             set_header_correlation_id(request, validated_correlation_id)
 
         async def send_wrapper(message):
@@ -275,7 +277,7 @@ class CorrelationIdMiddleware:
                 # Get the original response headers
                 headers = message.setdefault("headers", [])
                 header_name = CORRELATION_ID_HEADER_NAME.lower().encode()
-                header_value = validated_correlation_id.encode()
+                header_value = str(validated_correlation_id).encode()
                 for header in headers:
                     key = header[0]
                     if key.lower() == header_name:

--- a/src/ghga_service_commons/api/api.py
+++ b/src/ghga_service_commons/api/api.py
@@ -34,7 +34,6 @@ from hexkit.correlation import (
     correlation_id_from_str,
     new_correlation_id,
     set_correlation_id,
-    validate_correlation_id,
 )
 from pydantic import UUID4, Field
 from pydantic_settings import BaseSettings
@@ -193,7 +192,6 @@ def get_validated_correlation_id(
         log.debug("Generated new correlation id: %s", correlation_id)
     else:
         valid_correlation_id = correlation_id_from_str(correlation_id)
-        validate_correlation_id(valid_correlation_id)
     return valid_correlation_id
 
 
@@ -367,7 +365,7 @@ def configure_app(app: FastAPI, config: ApiConfigBase):
 
     app.add_middleware(RequestLoggingMiddleware)
     app.add_middleware(CorrelationIdMiddleware, config.generate_correlation_id)
-    app.add_middleware(CORSMiddleware, **kwargs)  # type: ignore[arg-type]
+    app.add_middleware(CORSMiddleware, **kwargs)
 
     # Configure the exception handler to issue error according to httpyexpect model:
     configure_exception_handler(app)

--- a/src/ghga_service_commons/http/correlation.py
+++ b/src/ghga_service_commons/http/correlation.py
@@ -45,7 +45,7 @@ async def _cid_request_hook(request, generate_correlation_id: bool):
             correlation_id = new_correlation_id()
         else:
             raise
-    request.headers[CORRELATION_ID_HEADER_NAME] = correlation_id
+    request.headers[CORRELATION_ID_HEADER_NAME] = str(correlation_id)
 
 
 def attach_correlation_id_to_requests(

--- a/src/ghga_service_commons/utils/utc_dates.py
+++ b/src/ghga_service_commons/utils/utc_dates.py
@@ -28,6 +28,7 @@ __all__ = ["UTC", "UTCDatetime", "assert_tz_is_utc", "convert_tz_to_utc", "now_a
 UTC = timezone.utc
 
 
+# TODO: Use utils from hexkit maybe?
 def assert_tz_is_utc() -> None:
     """Verify that the default timezone is set to UTC.
 

--- a/src/ghga_service_commons/utils/utc_dates.py
+++ b/src/ghga_service_commons/utils/utc_dates.py
@@ -28,7 +28,6 @@ __all__ = ["UTC", "UTCDatetime", "assert_tz_is_utc", "convert_tz_to_utc", "now_a
 UTC = timezone.utc
 
 
-# TODO: Use utils from hexkit maybe?
 def assert_tz_is_utc() -> None:
     """Verify that the default timezone is set to UTC.
 
@@ -67,5 +66,7 @@ def now_as_utc() -> UTCDatetime:
     """Return the current datetime with UTC timezone.
 
     Note: This is different from datetime.utcnow() which has no timezone.
+    Note: For use in Pydantic models, prefer using `hexkit.utils.now_utc_ms_prec()`
+    which returns a UTC datetime with millisecond-only precision.
     """
     return UTCDatetime.now(UTC)

--- a/tests/integration/test_correlation.py
+++ b/tests/integration/test_correlation.py
@@ -27,7 +27,6 @@ from hexkit.correlation import (
     get_correlation_id,
     new_correlation_id,
     set_new_correlation_id,
-    validate_correlation_id,
 )
 
 from ghga_service_commons.api.api import (
@@ -207,7 +206,6 @@ async def test_async_client(generate_correlation_id: bool):
         correlation_id = correlation_id_from_str(
             request.headers[CORRELATION_ID_HEADER_NAME]
         )
-        validate_correlation_id(correlation_id)
         return correlation_id
 
     # Create an AsyncClient instance (NOT AsyncTestClient!)
@@ -230,7 +228,6 @@ async def test_async_client(generate_correlation_id: bool):
             correlation_id = correlation_id_from_str(
                 response.headers[CORRELATION_ID_HEADER_NAME]
             )
-            validate_correlation_id(correlation_id)
 
         # Verify that the CID is passed when it exists
         async with set_new_correlation_id() as correlation_id:

--- a/tests/integration/test_correlation.py
+++ b/tests/integration/test_correlation.py
@@ -23,6 +23,7 @@ import pytest
 from fastapi import FastAPI, Request, Response
 from hexkit.correlation import (
     CorrelationIdContextError,
+    correlation_id_from_str,
     get_correlation_id,
     new_correlation_id,
     set_new_correlation_id,
@@ -91,27 +92,32 @@ async def test_middleware_responses(use_unexpected_cid: bool):
     @app.get("/")
     async def endpoint():
         if use_unexpected_cid:
-            return Response(headers={CORRELATION_ID_HEADER_NAME: new_correlation_id()})
+            return Response(
+                headers={CORRELATION_ID_HEADER_NAME: str(new_correlation_id())}
+            )
         return "done"
 
-    async with set_new_correlation_id() as correlation_id:
-        async with AsyncTestClient(app=app) as rest_client:
-            # If 'use_unexpected_cid' is set, then the endpoint will return a different
-            #  cid in the header. The middleware should detect this and raise an error.
-            #  Our services should not have a reason to modify this value.
-            with (
-                pytest.raises(UnexpectedCorrelationIdError)
-                if use_unexpected_cid
-                else nullcontext()
-            ):
-                response = await rest_client.get(
-                    "/", headers={CORRELATION_ID_HEADER_NAME: correlation_id}
-                )
+    async with (
+        set_new_correlation_id() as correlation_id,
+        AsyncTestClient(app=app) as rest_client,
+    ):
+        # If 'use_unexpected_cid' is set, then the endpoint will return a different
+        #  cid in the header. The middleware should detect this and raise an error.
+        #  Our services should not have a reason to modify this value.
+        correlation_id = str(correlation_id)
+        with (
+            pytest.raises(UnexpectedCorrelationIdError)
+            if use_unexpected_cid
+            else nullcontext()
+        ):
+            response = await rest_client.get(
+                "/", headers={CORRELATION_ID_HEADER_NAME: correlation_id}
+            )
 
-            # Only check the response headers now if we used the normal CID
-            if not use_unexpected_cid:
-                assert CORRELATION_ID_HEADER_NAME in response.headers
-                assert response.headers[CORRELATION_ID_HEADER_NAME] == correlation_id
+        # Only check the response headers now if we used the normal CID
+        if not use_unexpected_cid:
+            assert CORRELATION_ID_HEADER_NAME in response.headers
+            assert response.headers[CORRELATION_ID_HEADER_NAME] == correlation_id
 
 
 async def test_correlation_id_request_hook():
@@ -134,7 +140,7 @@ async def test_correlation_id_request_hook():
     @this_service.get("/")
     async def first_endpoint():
         """Call the other endpoint"""
-        correlation_id = get_correlation_id()
+        correlation_id = str(get_correlation_id())
 
         async with AsyncTestClient(app=some_other_service) as client:
             # Make a call to the other API and verify that the CID isn't passed on
@@ -160,6 +166,7 @@ async def test_correlation_id_request_hook():
         # Verify that the CID is propagated from here to the final API endpoint and back
         async with set_new_correlation_id() as correlation_id:
             response = await rest_client.get("/")
+            correlation_id = str(correlation_id)
             assert response.json() == correlation_id
             assert response.headers[CORRELATION_ID_HEADER_NAME] == correlation_id
 
@@ -197,8 +204,11 @@ async def test_async_client(generate_correlation_id: bool):
     async def endpoint(request: Request):
         """Return the correlation ID header value from the request."""
         assert CORRELATION_ID_HEADER_NAME in request.headers
-        validate_correlation_id(request.headers[CORRELATION_ID_HEADER_NAME])
-        return request.headers[CORRELATION_ID_HEADER_NAME]
+        correlation_id = correlation_id_from_str(
+            request.headers[CORRELATION_ID_HEADER_NAME]
+        )
+        validate_correlation_id(correlation_id)
+        return correlation_id
 
     # Create an AsyncClient instance (NOT AsyncTestClient!)
     async with AsyncClient(
@@ -217,10 +227,14 @@ async def test_async_client(generate_correlation_id: bool):
         # Check the response headers, but only in the non-erring case
         if generate_correlation_id:
             assert CORRELATION_ID_HEADER_NAME in response.headers
-            validate_correlation_id(response.headers[CORRELATION_ID_HEADER_NAME])
+            correlation_id = correlation_id_from_str(
+                response.headers[CORRELATION_ID_HEADER_NAME]
+            )
+            validate_correlation_id(correlation_id)
 
         # Verify that the CID is passed when it exists
         async with set_new_correlation_id() as correlation_id:
+            correlation_id = str(correlation_id)
             response = await client.get("/")
             assert response.headers[CORRELATION_ID_HEADER_NAME] == correlation_id
             assert response.json() == correlation_id

--- a/tests/integration/test_correlation.py
+++ b/tests/integration/test_correlation.py
@@ -104,20 +104,20 @@ async def test_middleware_responses(use_unexpected_cid: bool):
         # If 'use_unexpected_cid' is set, then the endpoint will return a different
         #  cid in the header. The middleware should detect this and raise an error.
         #  Our services should not have a reason to modify this value.
-        correlation_id = str(correlation_id)
+        cid_string = str(correlation_id)
         with (
             pytest.raises(UnexpectedCorrelationIdError)
             if use_unexpected_cid
             else nullcontext()
         ):
             response = await rest_client.get(
-                "/", headers={CORRELATION_ID_HEADER_NAME: correlation_id}
+                "/", headers={CORRELATION_ID_HEADER_NAME: cid_string}
             )
 
         # Only check the response headers now if we used the normal CID
         if not use_unexpected_cid:
             assert CORRELATION_ID_HEADER_NAME in response.headers
-            assert response.headers[CORRELATION_ID_HEADER_NAME] == correlation_id
+            assert response.headers[CORRELATION_ID_HEADER_NAME] == cid_string
 
 
 async def test_correlation_id_request_hook():
@@ -166,9 +166,9 @@ async def test_correlation_id_request_hook():
         # Verify that the CID is propagated from here to the final API endpoint and back
         async with set_new_correlation_id() as correlation_id:
             response = await rest_client.get("/")
-            correlation_id = str(correlation_id)
-            assert response.json() == correlation_id
-            assert response.headers[CORRELATION_ID_HEADER_NAME] == correlation_id
+            cid_string = str(correlation_id)
+            assert response.json() == cid_string
+            assert response.headers[CORRELATION_ID_HEADER_NAME] == cid_string
 
 
 async def test_hook_errors():
@@ -234,7 +234,7 @@ async def test_async_client(generate_correlation_id: bool):
 
         # Verify that the CID is passed when it exists
         async with set_new_correlation_id() as correlation_id:
-            correlation_id = str(correlation_id)
+            cid_string = str(correlation_id)
             response = await client.get("/")
-            assert response.headers[CORRELATION_ID_HEADER_NAME] == correlation_id
-            assert response.json() == correlation_id
+            assert response.headers[CORRELATION_ID_HEADER_NAME] == cid_string
+            assert response.json() == cid_string

--- a/tests/unit/api/test_correlation.py
+++ b/tests/unit/api/test_correlation.py
@@ -15,6 +15,8 @@
 #
 """Tests for the correlation ID functionality."""
 
+from uuid import UUID
+
 from fastapi import Request
 
 from ghga_service_commons.api.api import (
@@ -31,7 +33,7 @@ def test_header_update_function():
         "path": "/",
         "headers": [],
     }
-
+    cid = UUID("9c68468c-c82a-4744-80aa-a06e3a54e5b5")
     request = Request(scope=scope)
-    set_header_correlation_id(request, "id123")
-    assert request.headers.get(CORRELATION_ID_HEADER_NAME) == "id123"
+    set_header_correlation_id(request, cid)
+    assert request.headers.get(CORRELATION_ID_HEADER_NAME) == str(cid)


### PR DESCRIPTION
This gets hexkit v6 and bumps the version to `5.0.0`. This is a major version change because some functions in the `api` module were updated with new return/param types (UUID4 instead of str)