### PR TITLE
Fix keyword argument for exposed headers

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_service_commons"
-version = "4.1.1"
+version = "4.1.2"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_service_commons"
-version = "4.1.1"
+version = "4.1.2"
 description = "A library that contains common functionality used in services of GHGA"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/ghga_service_commons/api/api.py
+++ b/src/ghga_service_commons/api/api.py
@@ -361,7 +361,7 @@ def configure_app(app: FastAPI, config: ApiConfigBase):
     if config.cors_allow_credentials is not None:
         kwargs["allow_credentials"] = config.cors_allow_credentials
     if config.cors_exposed_headers is not None:
-        kwargs["exposed_headers"] = config.cors_exposed_headers
+        kwargs["expose_headers"] = config.cors_exposed_headers
 
     app.add_middleware(RequestLoggingMiddleware)
     app.add_middleware(CorrelationIdMiddleware, config.generate_correlation_id)


### PR DESCRIPTION
I've encountered the error below when running UI tests. When I check the [FastAPI CORSMiddleware docs](https://fastapi.tiangolo.com/tutorial/cors/#use-corsmiddleware) the argument is `expose_headers` instead of `exposes_headers`.


```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.12/site-packages/starlette/applications.py", line 111, in __call__
    self.middleware_stack = self.build_middleware_stack()
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/opentelemetry/instrumentation/fastapi/__init__.py", line 299, in build_middleware_stack
    self._original_build_middleware_stack()  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/starlette/applications.py", line 98, in build_middleware_stack
    app = cls(app, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: CORSMiddleware.__init__() got an unexpected keyword argument 'exposed_headers'`
```