### PR TITLE
Add config setting timeout_keep_alive with increased default (GSI-2132)

### DIFF
--- a/src/ghga_service_commons/api/api.py
+++ b/src/ghga_service_commons/api/api.py
@@ -79,6 +79,16 @@ class ApiConfigBase(BaseSettings):
         ),
     )
     workers: int = Field(default=1, description="Number of workers processes to run.")
+    timeout_keep_alive: int = Field(
+        default=90,
+        description=(
+            "The time in seconds to keep an idle connection open for subsequent"
+            + " requests before closing it. This value should be higher than the"
+            + " timeout used by any client or reverse proxy to avoid premature"
+            + " connection closures."
+        ),
+        examples=[5, 90, 5400],
+    )
     api_root_path: str = Field(
         default="",
         description=(
@@ -406,6 +416,7 @@ async def run_server(app: FastAPI | str, config: ApiConfigBase):
         log_config=None,
         reload=config.auto_reload,
         workers=config.workers,
+        timeout_keep_alive=config.timeout_keep_alive,
         ws="websockets-sansio",
     )
 


### PR DESCRIPTION
uvicorn’s default for `--timeout-keep-alive` is 5s.

That’s fine for “direct-to-client” setups, but it’s often a bad fit in a service mesh, because istio/Envoy will happily keep upstream pools around much longer (idle timeout default is commonly 1 hour if you don’t set it).

That mismatch (proxy thinks a pooled connection is still reusable, app has already closed it) is exactly the kind of thing that shows up as occasional upstream resets/503s.

For our internal microservice HTTP/1.1 keep-alive a better default value is 90s, which we use as our new default, but the value is also configurable per service now.

We could also try to match Envoy’s long defaults by setting Uvicorn keep-alive to something huge, but it’s usually a worse default in microservice meshes because:
- many peers and long idle times means lots of idle sockets
- higher baseline file descriptors memory use
- slower cleanup of half-dead network paths

Therefore it is recommeded to use short-ish but consistent timeouts, with the proxy shorter than the app.

See also [this comment](https://github.com/istio/istio/issues/55138#issuecomment-2666855044) with some more explanations.