### PR TITLE
Fix ternary bug

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_service_commons"
-version = "7.0.1"
+version = "7.0.2"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_service_commons"
-version = "7.0.1"
+version = "7.0.2"
 description = "A library that contains common functionality used in services of GHGA"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/ghga_service_commons/transports/factory.py
+++ b/src/ghga_service_commons/transports/factory.py
@@ -41,10 +41,10 @@ class CompositeTransportFactory:
         Those have to be provided directly to the custom base_transport passed into this method.
         """
         base_transport = (
-            base_transport or AsyncHTTPTransport(limits=limits)
+            base_transport or (AsyncHTTPTransport(limits=limits)
             if limits
             else AsyncHTTPTransport()
-        )
+        ))
         ratelimiting_transport = AsyncRateLimitingTransport(
             config=config, transport=base_transport
         )

--- a/src/ghga_service_commons/transports/factory.py
+++ b/src/ghga_service_commons/transports/factory.py
@@ -40,11 +40,9 @@ class CompositeTransportFactory:
         If provided, a custom base_transport class is used and any limits are ignored.
         Those have to be provided directly to the custom base_transport passed into this method.
         """
-        base_transport = (
-            base_transport or (AsyncHTTPTransport(limits=limits)
-            if limits
-            else AsyncHTTPTransport()
-        ))
+        base_transport = base_transport or (
+            AsyncHTTPTransport(limits=limits) if limits else AsyncHTTPTransport()
+        )
         ratelimiting_transport = AsyncRateLimitingTransport(
             config=config, transport=base_transport
         )


### PR DESCRIPTION
fix: preserve caller-supplied base_transport when limits is None Operator precedence caused `a or b if c else d` to parse as `(a or b) if c else d`, dropping the supplied base_transport when limits was falsy. Parenthesize the ternary.