### PR TITLE
Fix/proxy no proxy and ca bundle

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_service_commons"
-version = "7.0.3"
+version = "7.0.4"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_service_commons"
-version = "7.0.3"
+version = "7.0.4"
 description = "A library that contains common functionality used in services of GHGA"
 dependencies = [
     "pydantic >=2, <3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_service_commons"
-version = "7.0.4"
+version = "7.0.3"
 description = "A library that contains common functionality used in services of GHGA"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/ghga_service_commons/transports/factory.py
+++ b/src/ghga_service_commons/transports/factory.py
@@ -15,6 +15,9 @@
 
 """Provides factories for different flavors of httpx.AsyncHTTPTransport."""
 
+import os
+import ssl
+
 from hishel import AsyncSqliteStorage, FilterPolicy
 from hishel.httpx import AsyncCacheTransport
 from httpx import AsyncBaseTransport, AsyncHTTPTransport, Limits
@@ -22,6 +25,24 @@ from httpx import AsyncBaseTransport, AsyncHTTPTransport, Limits
 from .config import CompositeCacheConfig, CompositeConfig
 from .ratelimiting import AsyncRateLimitingTransport
 from .retry import AsyncRetryTransport
+
+
+def _get_ssl_verify() -> ssl.SSLContext | bool:
+    """Determine the SSL verification setting for outgoing transports.
+
+    Honors the standard ``REQUESTS_CA_BUNDLE`` and ``SSL_CERT_FILE`` environment
+    variables (the same ones respected by ``requests``, ``urllib3`` and boto3) so
+    that deployments behind SSL-inspecting proxies or with self-signed/custom CA
+    chains verify correctly. ``REQUESTS_CA_BUNDLE`` takes precedence.
+
+    If either variable is set, an ``ssl.SSLContext`` loaded from the referenced CA
+    bundle is returned. If neither is set, ``True`` is returned so that httpx keeps
+    its default behavior (certifi's bundled root certificates).
+    """
+    ca_bundle = os.environ.get("REQUESTS_CA_BUNDLE") or os.environ.get("SSL_CERT_FILE")
+    if ca_bundle:
+        return ssl.create_default_context(cafile=ca_bundle)
+    return True
 
 
 class CompositeTransportFactory:
@@ -40,8 +61,11 @@ class CompositeTransportFactory:
         If provided, a custom base_transport class is used and any limits are ignored.
         Those have to be provided directly to the custom base_transport passed into this method.
         """
+        verify = _get_ssl_verify()
         base_transport = base_transport or (
-            AsyncHTTPTransport(limits=limits) if limits else AsyncHTTPTransport()
+            AsyncHTTPTransport(limits=limits, verify=verify)
+            if limits
+            else AsyncHTTPTransport(verify=verify)
         )
         ratelimiting_transport = AsyncRateLimitingTransport(
             config=config, transport=base_transport

--- a/src/ghga_service_commons/transports/factory.py
+++ b/src/ghga_service_commons/transports/factory.py
@@ -27,7 +27,7 @@ from .ratelimiting import AsyncRateLimitingTransport
 from .retry import AsyncRetryTransport
 
 
-def _get_ssl_verify() -> ssl.SSLContext | bool:
+def get_ssl_verify() -> ssl.SSLContext | bool:
     """Determine the SSL verification setting for outgoing transports.
 
     Honors the standard ``REQUESTS_CA_BUNDLE`` and ``SSL_CERT_FILE`` environment
@@ -61,7 +61,7 @@ class CompositeTransportFactory:
         If provided, a custom base_transport class is used and any limits are ignored.
         Those have to be provided directly to the custom base_transport passed into this method.
         """
-        verify = _get_ssl_verify()
+        verify = get_ssl_verify()
         base_transport = base_transport or (
             AsyncHTTPTransport(limits=limits, verify=verify)
             if limits

--- a/src/ghga_service_commons/transports/proxy_handling.py
+++ b/src/ghga_service_commons/transports/proxy_handling.py
@@ -89,6 +89,6 @@ def _get_base_proxies_from_env() -> dict[str, AsyncHTTPTransport | None]:
     """
     verify = get_ssl_verify()
     return {
-        key: (AsyncHTTPTransport(proxy=url, verify=verify) if url is not None else None)
+        key: None if url is None else (AsyncHTTPTransport(proxy=url, verify=verify))
         for key, url in _utils.get_environment_proxies().items()
     }

--- a/src/ghga_service_commons/transports/proxy_handling.py
+++ b/src/ghga_service_commons/transports/proxy_handling.py
@@ -32,7 +32,7 @@ by this handling.
 from httpx import AsyncBaseTransport, AsyncHTTPTransport, Limits, _utils
 
 from .config import CompositeCacheConfig, CompositeConfig
-from .factory import CompositeTransportFactory, _get_ssl_verify
+from .factory import CompositeTransportFactory, get_ssl_verify
 
 
 def cached_ratelimiting_retry_proxies(
@@ -87,7 +87,7 @@ def _get_base_proxies_from_env() -> dict[str, AsyncHTTPTransport | None]:
     ``None`` so that NO_PROXY is respected (httpx connects directly for them) instead
     of being silently routed through a proxy.
     """
-    verify = _get_ssl_verify()
+    verify = get_ssl_verify()
     return {
         key: (AsyncHTTPTransport(proxy=url, verify=verify) if url is not None else None)
         for key, url in _utils.get_environment_proxies().items()

--- a/src/ghga_service_commons/transports/proxy_handling.py
+++ b/src/ghga_service_commons/transports/proxy_handling.py
@@ -20,12 +20,19 @@ is provided.
 For now this logic is simplified, i.e. this is not in sync with `trust_env` on the
 client and will parse env proxies unconditionally.
 If you don't want to trust the env, don't use the functions from this module.
+
+NO_PROXY is now respected: hosts excluded from proxying via NO_PROXY are kept as
+`None` mounts, which tells httpx to connect directly for them. Note that wildcard and
+CIDR NO_PROXY entries behave according to httpx's mount pattern matching rather than
+httpx's own NO_PROXY logic (which is bypassed entirely once `mounts` are supplied).
+This is a pre-existing limitation of routing through `mounts` and is not introduced
+by this handling.
 """
 
-from httpx import AsyncHTTPTransport, Limits, _utils
+from httpx import AsyncBaseTransport, AsyncHTTPTransport, Limits, _utils
 
 from .config import CompositeCacheConfig, CompositeConfig
-from .factory import CompositeTransportFactory
+from .factory import CompositeTransportFactory, _get_ssl_verify
 
 
 def cached_ratelimiting_retry_proxies(
@@ -36,8 +43,12 @@ def cached_ratelimiting_retry_proxies(
 
     The returned dictionary needs to be provided as `mounts` to the client.
     """
-    mounts = dict()
+    mounts: dict[str, AsyncBaseTransport | None] = dict()
     for key, transport in _get_base_proxies_from_env().items():
+        if transport is None:
+            # NO_PROXY host: keep None so httpx connects directly for this host.
+            mounts[key] = None
+            continue
         mounts[key] = (
             CompositeTransportFactory.create_cached_ratelimiting_retry_transport(
                 config=config, base_transport=transport, limits=limits
@@ -54,8 +65,12 @@ def ratelimiting_retry_proxies(
 
     The returned dictionary needs to be provided as `mounts` to the client.
     """
-    mounts = dict()
+    mounts: dict[str, AsyncBaseTransport | None] = dict()
     for key, transport in _get_base_proxies_from_env().items():
+        if transport is None:
+            # NO_PROXY host: keep None so httpx connects directly for this host.
+            mounts[key] = None
+            continue
         mounts[key] = CompositeTransportFactory.create_ratelimiting_retry_transport(
             config=config, base_transport=transport, limits=limits
         )
@@ -67,9 +82,13 @@ def _get_base_proxies_from_env() -> dict[str, AsyncHTTPTransport | None]:
 
     This will populate http, https and all proxy settings and create transports
     based on those proxy strings.
+
+    NO_PROXY hosts are returned by httpx with a ``None`` url; these are preserved as
+    ``None`` so that NO_PROXY is respected (httpx connects directly for them) instead
+    of being silently routed through a proxy.
     """
+    verify = _get_ssl_verify()
     return {
-        key: AsyncHTTPTransport(proxy=url)
+        key: (AsyncHTTPTransport(proxy=url, verify=verify) if url is not None else None)
         for key, url in _utils.get_environment_proxies().items()
-        if url is not None
     }

--- a/tests/unit/transports/test_factory.py
+++ b/tests/unit/transports/test_factory.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import certifi
 import pytest
 
-from ghga_service_commons.transports.factory import _get_ssl_verify
+from ghga_service_commons.transports.factory import get_ssl_verify
 
 
 @pytest.fixture
@@ -40,7 +40,7 @@ def test_get_ssl_verify_requests_ca_bundle(
     monkeypatch.delenv("SSL_CERT_FILE", raising=False)
     monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(ca_bundle))
 
-    verify = _get_ssl_verify()
+    verify = get_ssl_verify()
 
     assert isinstance(verify, ssl.SSLContext)
 
@@ -50,7 +50,7 @@ def test_get_ssl_verify_ssl_cert_file(monkeypatch: pytest.MonkeyPatch, ca_bundle
     monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
     monkeypatch.setenv("SSL_CERT_FILE", str(ca_bundle))
 
-    verify = _get_ssl_verify()
+    verify = get_ssl_verify()
 
     assert isinstance(verify, ssl.SSLContext)
 
@@ -60,7 +60,7 @@ def test_get_ssl_verify_neither_set(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
     monkeypatch.delenv("SSL_CERT_FILE", raising=False)
 
-    verify = _get_ssl_verify()
+    verify = get_ssl_verify()
 
     assert verify is True
 
@@ -75,6 +75,6 @@ def test_get_ssl_verify_requests_ca_bundle_precedence(
     monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(ca_bundle))
     monkeypatch.setenv("SSL_CERT_FILE", str(missing))
 
-    verify = _get_ssl_verify()
+    verify = get_ssl_verify()
 
     assert isinstance(verify, ssl.SSLContext)

--- a/tests/unit/transports/test_factory.py
+++ b/tests/unit/transports/test_factory.py
@@ -1,0 +1,80 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the transport factory, including SSL verification handling."""
+
+import shutil
+import ssl
+from pathlib import Path
+
+import certifi
+import pytest
+
+from ghga_service_commons.transports.factory import _get_ssl_verify
+
+
+@pytest.fixture
+def ca_bundle(tmp_path: Path) -> Path:
+    """Provide a path to a real, loadable CA bundle copied into a temp dir."""
+    bundle = tmp_path / "ca-bundle.pem"
+    shutil.copyfile(certifi.where(), bundle)
+    return bundle
+
+
+def test_get_ssl_verify_requests_ca_bundle(
+    monkeypatch: pytest.MonkeyPatch, ca_bundle: Path
+):
+    """REQUESTS_CA_BUNDLE set -> returns a loaded SSLContext."""
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(ca_bundle))
+
+    verify = _get_ssl_verify()
+
+    assert isinstance(verify, ssl.SSLContext)
+
+
+def test_get_ssl_verify_ssl_cert_file(monkeypatch: pytest.MonkeyPatch, ca_bundle: Path):
+    """SSL_CERT_FILE set (REQUESTS_CA_BUNDLE unset) -> returns a loaded SSLContext."""
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.setenv("SSL_CERT_FILE", str(ca_bundle))
+
+    verify = _get_ssl_verify()
+
+    assert isinstance(verify, ssl.SSLContext)
+
+
+def test_get_ssl_verify_neither_set(monkeypatch: pytest.MonkeyPatch):
+    """Neither env var set -> returns True (httpx default = certifi)."""
+    monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+
+    verify = _get_ssl_verify()
+
+    assert verify is True
+
+
+def test_get_ssl_verify_requests_ca_bundle_precedence(
+    monkeypatch: pytest.MonkeyPatch, ca_bundle: Path, tmp_path: Path
+):
+    """Both set -> REQUESTS_CA_BUNDLE takes precedence over SSL_CERT_FILE."""
+    # Point SSL_CERT_FILE at a non-existent path; if it were used, loading the
+    # context would raise. Successful loading proves REQUESTS_CA_BUNDLE won.
+    missing = tmp_path / "does-not-exist.pem"
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(ca_bundle))
+    monkeypatch.setenv("SSL_CERT_FILE", str(missing))
+
+    verify = _get_ssl_verify()
+
+    assert isinstance(verify, ssl.SSLContext)

--- a/tests/unit/transports/test_factory.py
+++ b/tests/unit/transports/test_factory.py
@@ -68,13 +68,23 @@ def test_get_ssl_verify_neither_set(monkeypatch: pytest.MonkeyPatch):
 def test_get_ssl_verify_requests_ca_bundle_precedence(
     monkeypatch: pytest.MonkeyPatch, ca_bundle: Path, tmp_path: Path
 ):
-    """Both set -> REQUESTS_CA_BUNDLE takes precedence over SSL_CERT_FILE."""
-    # Point SSL_CERT_FILE at a non-existent path; if it were used, loading the
-    # context would raise. Successful loading proves REQUESTS_CA_BUNDLE won.
-    missing = tmp_path / "does-not-exist.pem"
+    """Both set and both loadable -> REQUESTS_CA_BUNDLE wins over SSL_CERT_FILE.
+
+    Both env vars point to valid, loadable bundles that differ in content, so the
+    loaded CA set identifies which file was actually used: the full certifi bundle
+    (REQUESTS_CA_BUNDLE) versus a single-cert subset (SSL_CERT_FILE).
+    """
+    single_cert_bundle = tmp_path / "single-cert.pem"
+    marker = "-----END CERTIFICATE-----"
+    first_cert = ca_bundle.read_text().split(marker)[0] + marker + "\n"
+    single_cert_bundle.write_text(first_cert)
+
     monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(ca_bundle))
-    monkeypatch.setenv("SSL_CERT_FILE", str(missing))
+    monkeypatch.setenv("SSL_CERT_FILE", str(single_cert_bundle))
 
     verify = get_ssl_verify()
 
     assert isinstance(verify, ssl.SSLContext)
+    expected = ssl.create_default_context(cafile=str(ca_bundle))
+    assert len(verify.get_ca_certs()) == len(expected.get_ca_certs())
+    assert len(verify.get_ca_certs()) > 1

--- a/tests/unit/transports/test_proxy_handling.py
+++ b/tests/unit/transports/test_proxy_handling.py
@@ -157,11 +157,17 @@ def test_with_no_proxies(
         (CompositeCacheConfig, cached_ratelimiting_retry_proxies),
     ],
 )
-def test_filters_none_proxy_values(
+def test_preserves_no_proxy_values(
     config_class: type[CompositeConfig | CompositeCacheConfig],
     proxy_fn: Callable,
 ):
-    """Test that None proxy values are filtered out."""
+    """NO_PROXY hosts (None values) are preserved as ``None`` mounts.
+
+    httpx's built-in NO_PROXY handling is bypassed when ``mounts`` are supplied, so
+    the ``None`` entries are what tell httpx to connect directly for those hosts.
+    They must be kept as keys with ``None`` values, not dropped and not wrapped in
+    a transport.
+    """
     config = config_class()
 
     with patch(
@@ -174,11 +180,12 @@ def test_filters_none_proxy_values(
     ):
         mounts = proxy_fn(config)
 
-        # The function should filter out None values
-        assert len(mounts) == 2
-        assert HTTP_PROTOCOL in mounts
-        assert ALL_PROTOCOL in mounts
-        assert HTTPS_PROTOCOL not in mounts
+        # None (NO_PROXY) entries are kept as None, proxied entries are transports
+        assert len(mounts) == 3
+        assert HTTPS_PROTOCOL in mounts
+        assert mounts[HTTPS_PROTOCOL] is None
+        assert mounts[HTTP_PROTOCOL] is not None
+        assert mounts[ALL_PROTOCOL] is not None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

  Fixes two bugs in the custom httpx transport stack that break deployments behind corporate proxies and custom CA chains.

  - **NO_PROXY ignored:** `_get_base_proxies_from_env` dropped `None` entries, discarding NO_PROXY hosts. Since httpx's built-in NO_PROXY logic is bypassed when `mounts` are supplied, every host was routed through the proxy. NO_PROXY hosts are now preserved as `None` mounts (direct connection).
  - **Custom CA bundles ignored:** `AsyncHTTPTransport` always used certifi, ignoring `REQUESTS_CA_BUNDLE` / `SSL_CERT_FILE`. A new `_get_ssl_verify()` helper reads those env vars (REQUESTS_CA_BUNDLE first) and passes an `ssl.SSLContext` as `verify=` to every transport. Default behavior (certifi) is unchanged when neither is set.

  ## Notes

  - Public API (`ratelimiting_retry_proxies`, `cached_ratelimiting_retry_proxies`) unchanged.
  - Wildcard/CIDR NO_PROXY entries follow httpx mount pattern matching — a pre-existing limitation, not introduced here.

  ## Tests

  Added coverage for `_get_ssl_verify` (all four env-var combinations) and for NO_PROXY hosts producing `None` mounts. Full transport suite passes.