### PR TITLE
Handle retry_state.outcome better, log retry attempt before actual retry

### DIFF
--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_service_commons"
-version = "7.0.4"
+version = "7.0.5"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_service_commons"
-version = "7.0.4"
+version = "7.0.5"
 description = "A library that contains common functionality used in services of GHGA"
 dependencies = [
     "pydantic >=2, <3",

--- a/src/ghga_service_commons/transports/retry.py
+++ b/src/ghga_service_commons/transports/retry.py
@@ -171,8 +171,11 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
         async def _attempt() -> httpx.Response:
             nonlocal latest_response
             if latest_response is not None:
-                await latest_response.aclose()
-                latest_response = None
+                # Always clear the reference so a later cleanup doesn't try to close the same response again.
+                try:
+                    await latest_response.aclose()
+                finally:
+                    latest_response = None
             # Strictly pass request as non kwarg arg to work around Otel httpx
             # instrumentation trying to extract from arg[0]
             latest_response = await self._transport.handle_async_request(request)
@@ -184,7 +187,12 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
             # Close the current connection on an exception. This should also deal with
             # the RetryError once all attempts are exhausted
             if latest_response is not None:
-                await latest_response.aclose()
+                try:
+                    await latest_response.aclose()
+                except Exception:
+                    log.warning(
+                        "Failed to close response during cleanup.", exc_info=True
+                    )
             raise
 
     async def aclose(self) -> None:  # noqa: D102

--- a/src/ghga_service_commons/transports/retry.py
+++ b/src/ghga_service_commons/transports/retry.py
@@ -141,7 +141,7 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
     This adds tenacity based retry logic around HTTP calls.
     Custom wait and stop strategies and logging after each attempt can be injected.
     The default wait strategy uses and exponential backoff, but ignores 429 responses,
-    so their retry-after header can be dealt with corrctly, if present.
+    so their retry-after header can be dealt with correctly, if present.
     """
 
     def __init__(  # noqa: PLR0913

--- a/src/ghga_service_commons/transports/retry.py
+++ b/src/ghga_service_commons/transports/retry.py
@@ -55,9 +55,8 @@ def _log_retry_stats(retry_state: RetryCallState):
     function_name = retry_state.fn.__qualname__
     attempt_number = retry_state.attempt_number
 
-    # Build stats from the per-call retry_state. The retry_object's `statistics` dict is
-    # shared across all requests using this transport, so mutating it here would corrupt
-    # the figures of concurrently in-flight requests.
+    # Build stats from the per-call retry_state. Don't mutate the retry_object's `statistics`
+    # dict as it's shared across all requests using this transport.
     stats: dict[str, Any] = {
         "function_name": function_name,
         "attempt_number": attempt_number,
@@ -66,9 +65,7 @@ def _log_retry_stats(retry_state: RetryCallState):
         "time_elapsed": round(time.monotonic() - retry_state.start_time, 3),
     }
 
-    # Enrich with details from the current attempt for debugging. Inspect the outcome
-    # without calling `.result()` on a failure, which would reraise and add a a frame to
-    # the traceback that's only noise.
+    # Enrich with details from the current attempt for debugging.
     if (outcome := retry_state.outcome) is not None:
         if outcome.failed:
             exc = outcome.exception()
@@ -119,9 +116,8 @@ class wait_exponential_ignore_429(wait_exponential):  # noqa: N801
 
     def __call__(self, retry_state: RetryCallState) -> float:
         """Copied from base class and adjusted."""
-        # Only read a successful outcome's result. Calling `.result()` on a failed outcome
-        # re-raises the stored exception instance and appends this frame to its traceback,
-        # polluting the eventual traceback even though the exception is caught here.
+        # Only read a successful outcome's result. Calling `.result()` pollutes the traceback
+        # if an exception is stored
         outcome = retry_state.outcome
         if outcome is not None and not outcome.failed:
             result = outcome.result()

--- a/src/ghga_service_commons/transports/retry.py
+++ b/src/ghga_service_commons/transports/retry.py
@@ -17,7 +17,6 @@
 
 import time
 from collections.abc import Callable
-from contextlib import suppress
 from logging import getLogger
 from types import TracebackType
 from typing import Any
@@ -56,30 +55,58 @@ def _log_retry_stats(retry_state: RetryCallState):
     function_name = retry_state.fn.__qualname__
     attempt_number = retry_state.attempt_number
 
-    # Get internal statistics from the current retry object
-    stats = retry_state.retry_object.statistics
-    stats["function_name"] = function_name
-    stats["time_elapsed"] = round(time.monotonic() - stats["start_time"], 3)
-    stats["start_time"] = round(stats["start_time"], 3)
-    stats["idle_for"] = round(stats["idle_for"], 3)
+    # Build stats from the per-call retry_state. The retry_object's `statistics` dict is
+    # shared across all requests using this transport, so mutating it here would corrupt
+    # the figures of concurrently in-flight requests.
+    stats: dict[str, Any] = {
+        "function_name": function_name,
+        "attempt_number": attempt_number,
+        "start_time": round(retry_state.start_time, 3),
+        "idle_for": round(retry_state.idle_for, 3),
+        "time_elapsed": round(time.monotonic() - retry_state.start_time, 3),
+    }
 
-    # Enrich with details from current attempt for debugging
-    if outcome := retry_state.outcome:
-        try:
-            result = outcome.result()
-        except Exception as exc:
+    # Enrich with details from the current attempt for debugging. Inspect the outcome
+    # without calling `.result()` on a failure, which would reraise and add a a frame to
+    # the traceback that's only noise.
+    if (outcome := retry_state.outcome) is not None:
+        if outcome.failed:
+            exc = outcome.exception()
             stats["exception_type"] = type(exc)
             stats["exception_message"] = str(exc)
-        else:
-            if isinstance(result, httpx.Response):
-                stats["response_status_code"] = result.status_code
-                stats["response_headers"] = result.headers
+        elif isinstance(result := outcome.result(), httpx.Response):
+            stats["response_status_code"] = result.status_code
+            stats["response_headers"] = result.headers
 
     log.info(
         "Retry attempt number %i for function %s.",
         attempt_number,
         function_name,
         extra=stats,
+    )
+
+
+def _log_before_attempt(retry_state: RetryCallState):
+    """Basic logger printing the function name and attempt number before each attempt."""
+    if not retry_state.fn:
+        log.debug("No wrapped function found in retry state.")
+        return
+
+    function_name = retry_state.fn.__qualname__
+    attempt_number = retry_state.attempt_number
+
+    log.info(
+        "Starting attempt number %i for function %s.",
+        attempt_number,
+        function_name,
+        # `args`/`kwargs` are reserved LogRecord attribute names, so the call arguments
+        # are exposed under non-clashing keys.
+        extra={
+            "function_name": function_name,
+            "attempt_number": attempt_number,
+            "call_args": retry_state.args,
+            "call_kwargs": retry_state.kwargs,
+        },
     )
 
 
@@ -92,15 +119,18 @@ class wait_exponential_ignore_429(wait_exponential):  # noqa: N801
 
     def __call__(self, retry_state: RetryCallState) -> float:
         """Copied from base class and adjusted."""
-        if retry_state.outcome:
-            with suppress(Exception):
-                result = retry_state.outcome.result()
-                if (
-                    isinstance(result, httpx.Response)
-                    and result.status_code == 429
-                    and not result.headers.get("Should-Wait")
-                ):
-                    return 0
+        # Only read a successful outcome's result. Calling `.result()` on a failed outcome
+        # re-raises the stored exception instance and appends this frame to its traceback,
+        # polluting the eventual traceback even though the exception is caught here.
+        outcome = retry_state.outcome
+        if outcome is not None and not outcome.failed:
+            result = outcome.result()
+            if (
+                isinstance(result, httpx.Response)
+                and result.status_code == 429
+                and not result.headers.get("Should-Wait")
+            ):
+                return 0
         try:
             exp = self.exp_base ** (retry_state.attempt_number - 1)
             result = self.multiplier * exp
@@ -118,13 +148,14 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
     so their retry-after header can be dealt with corrctly, if present.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         config: RetryTransportConfig,
         transport: httpx.AsyncBaseTransport,
         wait_strategy: Callable[[RetryTransportConfig], Any] = _default_wait_strategy,
         stop_strategy: Callable[[RetryTransportConfig], Any] = _default_stop_strategy,
         stats_logger: Callable[[RetryCallState], Any] = _log_retry_stats,
+        before_logger: Callable[[RetryCallState], Any] = _log_before_attempt,
     ) -> None:
         self._transport = transport
         self._retry_handler = _configure_retry_handler(
@@ -132,6 +163,7 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
             wait_strategy=wait_strategy,
             stop_strategy=stop_strategy,
             stats_logger=stats_logger,
+            before_logger=before_logger,
         )
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
@@ -160,6 +192,7 @@ def _configure_retry_handler(
     wait_strategy: Callable[[RetryTransportConfig], Any],
     stop_strategy: Callable[[RetryTransportConfig], Any],
     stats_logger: Callable[[RetryCallState], Any],
+    before_logger: Callable[[RetryCallState], Any],
 ):
     """Configure the AsyncRetrying instance that is used for handling retryable responses/exceptions."""
     return AsyncRetrying(
@@ -181,5 +214,6 @@ def _configure_retry_handler(
         ),
         stop=stop_strategy(config),
         wait=wait_strategy(config),
+        before=before_logger,
         after=stats_logger,
     )

--- a/src/ghga_service_commons/transports/retry.py
+++ b/src/ghga_service_commons/transports/retry.py
@@ -96,13 +96,9 @@ def _log_before_attempt(retry_state: RetryCallState):
         "Starting attempt number %i for function %s.",
         attempt_number,
         function_name,
-        # `args`/`kwargs` are reserved LogRecord attribute names, so the call arguments
-        # are exposed under non-clashing keys.
         extra={
             "function_name": function_name,
             "attempt_number": attempt_number,
-            "call_args": retry_state.args,
-            "call_kwargs": retry_state.kwargs,
         },
     )
 

--- a/src/ghga_service_commons/transports/retry.py
+++ b/src/ghga_service_commons/transports/retry.py
@@ -168,9 +168,28 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         """Handles HTTP requests and adds retry logic around calls."""
-        # Strictly pass request as non kwarg arg to work around Otel httpx instrumentation
-        # trying to extract from arg[0]
-        return await self._retry_handler(self._transport.handle_async_request, request)
+        # Track the latest response and close it before issuing the next attempt, leaving
+        # only the final response open to consume by the caller.
+        latest_response: httpx.Response | None = None
+
+        async def _attempt() -> httpx.Response:
+            nonlocal latest_response
+            if latest_response is not None:
+                await latest_response.aclose()
+                latest_response = None
+            # Strictly pass request as non kwarg arg to work around Otel httpx
+            # instrumentation trying to extract from arg[0]
+            latest_response = await self._transport.handle_async_request(request)
+            return latest_response
+
+        try:
+            return await self._retry_handler(_attempt)
+        except BaseException:
+            # Close the current connection on an exception. This should also deal with
+            # the RetryError once all attempts are exhausted
+            if latest_response is not None:
+                await latest_response.aclose()
+            raise
 
     async def aclose(self) -> None:  # noqa: D102
         await self._transport.aclose()

--- a/tests/unit/transports/test_factory.py
+++ b/tests/unit/transports/test_factory.py
@@ -21,8 +21,16 @@ from pathlib import Path
 
 import certifi
 import pytest
+from hishel.httpx import AsyncCacheTransport
+from httpx import AsyncHTTPTransport
 
-from ghga_service_commons.transports.factory import get_ssl_verify
+from ghga_service_commons.transports.config import CompositeCacheConfig, CompositeConfig
+from ghga_service_commons.transports.factory import (
+    CompositeTransportFactory,
+    get_ssl_verify,
+)
+from ghga_service_commons.transports.ratelimiting import AsyncRateLimitingTransport
+from ghga_service_commons.transports.retry import AsyncRetryTransport
 
 
 @pytest.fixture
@@ -88,3 +96,40 @@ def test_get_ssl_verify_requests_ca_bundle_precedence(
     expected = ssl.create_default_context(cafile=str(ca_bundle))
     assert len(verify.get_ca_certs()) == len(expected.get_ca_certs())
     assert len(verify.get_ca_certs()) > 1
+
+
+def test_create_ratelimiting_retry_transport_layers_transports():
+    """The retry transport wraps a rate limiting transport over an HTTP transport."""
+    transport = CompositeTransportFactory.create_ratelimiting_retry_transport(
+        CompositeConfig()
+    )
+
+    assert isinstance(transport, AsyncRetryTransport)
+    ratelimiting = transport._transport
+    assert isinstance(ratelimiting, AsyncRateLimitingTransport)
+    assert isinstance(ratelimiting._transport, AsyncHTTPTransport)
+
+
+def test_create_ratelimiting_retry_transport_uses_custom_base():
+    """A provided base transport is used at the bottom of the stack."""
+    base = AsyncHTTPTransport()
+
+    transport = CompositeTransportFactory.create_ratelimiting_retry_transport(
+        CompositeConfig(), base_transport=base
+    )
+
+    ratelimiting = transport._transport
+    assert isinstance(ratelimiting, AsyncRateLimitingTransport)
+    assert ratelimiting._transport is base
+
+
+def test_create_cached_ratelimiting_retry_transport_layers_transports():
+    """The cache transport wraps the retry and rate limiting transports."""
+    transport = CompositeTransportFactory.create_cached_ratelimiting_retry_transport(
+        CompositeCacheConfig()
+    )
+
+    assert isinstance(transport, AsyncCacheTransport)
+    retry = transport.next_transport
+    assert isinstance(retry, AsyncRetryTransport)
+    assert isinstance(retry._transport, AsyncRateLimitingTransport)

--- a/tests/unit/transports/test_factory.py
+++ b/tests/unit/transports/test_factory.py
@@ -99,7 +99,7 @@ def test_get_ssl_verify_requests_ca_bundle_precedence(
 
 
 def test_create_ratelimiting_retry_transport_layers_transports():
-    """The retry transport wraps a rate limiting transport over an HTTP transport."""
+    """Ensure the retry transport wraps a rate limiting transport over an HTTP transport."""
     transport = CompositeTransportFactory.create_ratelimiting_retry_transport(
         CompositeConfig()
     )
@@ -111,7 +111,7 @@ def test_create_ratelimiting_retry_transport_layers_transports():
 
 
 def test_create_ratelimiting_retry_transport_uses_custom_base():
-    """A provided base transport is used at the bottom of the stack."""
+    """Ensure a provided base transport is used at the bottom of the stack."""
     base = AsyncHTTPTransport()
 
     transport = CompositeTransportFactory.create_ratelimiting_retry_transport(

--- a/tests/unit/transports/test_ratelimiting.py
+++ b/tests/unit/transports/test_ratelimiting.py
@@ -1,0 +1,156 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the rate limiting transport handling of HTTP 429 responses."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from ghga_service_commons.transports.config import RateLimitingTransportConfig
+from ghga_service_commons.transports.ratelimiting import AsyncRateLimitingTransport
+
+# Patch target for the sleep used between requests, so tests never actually wait.
+SLEEP = "ghga_service_commons.transports.ratelimiting.asyncio.sleep"
+_REQUEST = httpx.Request("GET", "http://test")
+
+
+def _mock_transport(responses: list[httpx.Response]) -> AsyncMock:
+    """Build a transport mock returning the given responses in turn."""
+    transport = AsyncMock(spec=httpx.AsyncBaseTransport)
+    transport.handle_async_request = AsyncMock(side_effect=responses)
+    return transport
+
+
+def _ratelimiter(transport: AsyncMock, **config_kwargs) -> AsyncRateLimitingTransport:
+    """Wrap the transport in a rate limiting transport with the given config overrides."""
+    return AsyncRateLimitingTransport(
+        config=RateLimitingTransportConfig(**config_kwargs), transport=transport
+    )
+
+
+@pytest.mark.asyncio
+async def test_passes_through_non_429_response():
+    """Non-429 responses are returned unchanged without a Should-Wait header."""
+    response = httpx.Response(httpx.codes.OK)
+    ratelimiter = _ratelimiter(_mock_transport([response]))
+
+    result = await ratelimiter.handle_async_request(_REQUEST)
+
+    assert result is response
+    assert "Should-Wait" not in result.headers
+
+
+@pytest.mark.asyncio
+async def test_429_with_retry_after_sets_wait_time():
+    """A 429 with a Retry-After header stores the wait time and does not signal Should-Wait."""
+    response = httpx.Response(429, headers={"Retry-After": "5"})
+    ratelimiter = _ratelimiter(_mock_transport([response]))
+
+    with patch(SLEEP, new_callable=AsyncMock):
+        result = await ratelimiter.handle_async_request(_REQUEST)
+
+    assert ratelimiter._wait_time == 5.0
+    assert "Should-Wait" not in result.headers
+
+
+@pytest.mark.asyncio
+async def test_429_without_retry_after_sets_should_wait_header():
+    """A 429 without a Retry-After header signals Should-Wait and stores no wait time."""
+    response = httpx.Response(429)
+    ratelimiter = _ratelimiter(_mock_transport([response]))
+
+    with patch(SLEEP, new_callable=AsyncMock):
+        result = await ratelimiter.handle_async_request(_REQUEST)
+
+    assert result.headers["Should-Wait"] == "true"
+    assert ratelimiter._wait_time == 0
+
+
+@pytest.mark.asyncio
+async def test_carried_over_wait_time_triggers_sleep():
+    """A wait time learned from a 429 delays the next request by roughly that amount."""
+    responses = [
+        httpx.Response(429, headers={"Retry-After": "10"}),
+        httpx.Response(httpx.codes.OK),
+    ]
+    ratelimiter = _ratelimiter(_mock_transport(responses))
+
+    with patch(SLEEP, new_callable=AsyncMock) as mock_sleep:
+        await ratelimiter.handle_async_request(_REQUEST)
+        await ratelimiter.handle_async_request(_REQUEST)
+
+    # The second request happens right after the first, so almost the full delay remains.
+    last_sleep = mock_sleep.await_args_list[-1].args[0]
+    assert 9 < last_sleep <= 10
+
+
+@pytest.mark.asyncio
+async def test_jitter_adds_sleep_within_bounds():
+    """Configured jitter introduces a sleep no longer than the jitter bound."""
+    ratelimiter = _ratelimiter(
+        _mock_transport([httpx.Response(httpx.codes.OK)]), per_request_jitter=0.5
+    )
+
+    with patch(SLEEP, new_callable=AsyncMock) as mock_sleep:
+        await ratelimiter.handle_async_request(_REQUEST)
+
+    assert mock_sleep.await_args is not None
+    slept = mock_sleep.await_args.args[0]
+    assert 0 <= slept <= 0.5
+
+
+@pytest.mark.asyncio
+async def test_wait_time_reset_after_configured_requests():
+    """A stored wait time is cleared once the configured number of requests has passed."""
+    ratelimiter = _ratelimiter(
+        _mock_transport([httpx.Response(httpx.codes.OK)] * 2),
+        retry_after_applicable_for_num_requests=2,
+    )
+    # Simulate a wait time still in effect from a previous Retry-After response.
+    ratelimiter._wait_time = 5.0
+
+    with patch(SLEEP, new_callable=AsyncMock):
+        await ratelimiter.handle_async_request(_REQUEST)
+        # First request only counts towards the reset threshold.
+        assert ratelimiter._num_requests == 1
+        assert ratelimiter._wait_time == 5.0
+
+        await ratelimiter.handle_async_request(_REQUEST)
+
+    assert ratelimiter._num_requests == 0
+    assert ratelimiter._wait_time == 0
+
+
+@pytest.mark.asyncio
+async def test_aclose_delegates_to_wrapped_transport():
+    """Closing the rate limiting transport closes the transport it wraps."""
+    transport = _mock_transport([])
+
+    await _ratelimiter(transport).aclose()
+
+    transport.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_closes_transport():
+    """Exiting the async context manager closes the wrapped transport."""
+    transport = _mock_transport([])
+
+    async with _ratelimiter(transport) as ratelimiter:
+        assert isinstance(ratelimiter, AsyncRateLimitingTransport)
+
+    transport.aclose.assert_awaited_once()

--- a/tests/unit/transports/test_ratelimiting.py
+++ b/tests/unit/transports/test_ratelimiting.py
@@ -23,8 +23,9 @@ import pytest
 from ghga_service_commons.transports.config import RateLimitingTransportConfig
 from ghga_service_commons.transports.ratelimiting import AsyncRateLimitingTransport
 
-# Patch target for the sleep used between requests, so tests never actually wait.
-SLEEP = "ghga_service_commons.transports.ratelimiting.asyncio.sleep"
+# The per-request sleep is drawn from random.uniform keeps the real sleep at zero
+# while exposing the delay the transport computed.
+UNIFORM = "ghga_service_commons.transports.ratelimiting.random.uniform"
 _REQUEST = httpx.Request("GET", "http://test")
 
 
@@ -44,7 +45,7 @@ def _ratelimiter(transport: AsyncMock, **config_kwargs) -> AsyncRateLimitingTran
 
 @pytest.mark.asyncio
 async def test_passes_through_non_429_response():
-    """Non-429 responses are returned unchanged without a Should-Wait header."""
+    """Ensure non-429 responses are returned unchanged without a Should-Wait header."""
     response = httpx.Response(httpx.codes.OK)
     ratelimiter = _ratelimiter(_mock_transport([response]))
 
@@ -56,12 +57,11 @@ async def test_passes_through_non_429_response():
 
 @pytest.mark.asyncio
 async def test_429_with_retry_after_sets_wait_time():
-    """A 429 with a Retry-After header stores the wait time and does not signal Should-Wait."""
+    """Ensure a 429 with a Retry-After header stores the wait time and does not signal Should-Wait."""
     response = httpx.Response(429, headers={"Retry-After": "5"})
     ratelimiter = _ratelimiter(_mock_transport([response]))
 
-    with patch(SLEEP, new_callable=AsyncMock):
-        result = await ratelimiter.handle_async_request(_REQUEST)
+    result = await ratelimiter.handle_async_request(_REQUEST)
 
     assert ratelimiter._wait_time == 5.0
     assert "Should-Wait" not in result.headers
@@ -69,53 +69,40 @@ async def test_429_with_retry_after_sets_wait_time():
 
 @pytest.mark.asyncio
 async def test_429_without_retry_after_sets_should_wait_header():
-    """A 429 without a Retry-After header signals Should-Wait and stores no wait time."""
+    """Ensure a 429 without a Retry-After header signals Should-Wait and stores no wait time."""
     response = httpx.Response(429)
     ratelimiter = _ratelimiter(_mock_transport([response]))
 
-    with patch(SLEEP, new_callable=AsyncMock):
-        result = await ratelimiter.handle_async_request(_REQUEST)
+    result = await ratelimiter.handle_async_request(_REQUEST)
 
     assert result.headers["Should-Wait"] == "true"
     assert ratelimiter._wait_time == 0
 
 
 @pytest.mark.asyncio
-async def test_carried_over_wait_time_triggers_sleep():
-    """A wait time learned from a 429 delays the next request by roughly that amount."""
+async def test_carried_over_wait_time_is_applied_to_next_request():
+    """Ensure a wait time learned from a 429 is applied as the delay before the next request."""
     responses = [
         httpx.Response(429, headers={"Retry-After": "10"}),
         httpx.Response(httpx.codes.OK),
     ]
     ratelimiter = _ratelimiter(_mock_transport(responses))
 
-    with patch(SLEEP, new_callable=AsyncMock) as mock_sleep:
-        await ratelimiter.handle_async_request(_REQUEST)
-        await ratelimiter.handle_async_request(_REQUEST)
+    await ratelimiter.handle_async_request(_REQUEST)
 
-    # The second request happens right after the first, so almost the full delay remains.
-    last_sleep = mock_sleep.await_args_list[-1].args[0]
-    assert 9 < last_sleep <= 10
-
-
-@pytest.mark.asyncio
-async def test_jitter_adds_sleep_within_bounds():
-    """Configured jitter introduces a sleep no longer than the jitter bound."""
-    ratelimiter = _ratelimiter(
-        _mock_transport([httpx.Response(httpx.codes.OK)]), per_request_jitter=0.5
-    )
-
-    with patch(SLEEP, new_callable=AsyncMock) as mock_sleep:
+    # Returning 0.0 keeps the real asyncio.sleep instant; the bounds passed to uniform
+    # are the computed remaining wait, so the carried-over delay stays observable.
+    with patch(UNIFORM, return_value=0.0) as mock_uniform:
         await ratelimiter.handle_async_request(_REQUEST)
 
-    assert mock_sleep.await_args is not None
-    slept = mock_sleep.await_args.args[0]
-    assert 0 <= slept <= 0.5
+    remaining_wait = mock_uniform.call_args.args[0]
+    # The second request follows immediately, so almost the full delay still remains.
+    assert remaining_wait == pytest.approx(10, abs=0.5)
 
 
 @pytest.mark.asyncio
 async def test_wait_time_reset_after_configured_requests():
-    """A stored wait time is cleared once the configured number of requests has passed."""
+    """Ensure stored wait time is cleared once the configured number of requests has passed."""
     ratelimiter = _ratelimiter(
         _mock_transport([httpx.Response(httpx.codes.OK)] * 2),
         retry_after_applicable_for_num_requests=2,
@@ -123,13 +110,12 @@ async def test_wait_time_reset_after_configured_requests():
     # Simulate a wait time still in effect from a previous Retry-After response.
     ratelimiter._wait_time = 5.0
 
-    with patch(SLEEP, new_callable=AsyncMock):
-        await ratelimiter.handle_async_request(_REQUEST)
-        # First request only counts towards the reset threshold.
-        assert ratelimiter._num_requests == 1
-        assert ratelimiter._wait_time == 5.0
+    await ratelimiter.handle_async_request(_REQUEST)
+    # The first request only counts towards the reset threshold.
+    assert ratelimiter._num_requests == 1
+    assert ratelimiter._wait_time == 5.0
 
-        await ratelimiter.handle_async_request(_REQUEST)
+    await ratelimiter.handle_async_request(_REQUEST)
 
     assert ratelimiter._num_requests == 0
     assert ratelimiter._wait_time == 0

--- a/tests/unit/transports/test_retry.py
+++ b/tests/unit/transports/test_retry.py
@@ -13,36 +13,198 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the retry transport, focusing on connection handling across retries."""
+"""Tests for the retry transport: retry behavior, wait strategy, logging and cleanup."""
 
+import logging
+from collections.abc import Callable
 from unittest.mock import AsyncMock
 
 import httpx
 import pytest
-from tenacity import RetryError
+from tenacity import AsyncRetrying, RetryCallState, RetryError
 
 from ghga_service_commons.transports.config import RetryTransportConfig
-from ghga_service_commons.transports.retry import AsyncRetryTransport
+from ghga_service_commons.transports.retry import (
+    AsyncRetryTransport,
+    _default_stop_strategy,
+    _default_wait_strategy,
+    _log_before_attempt,
+    _log_retry_stats,
+    wait_exponential_ignore_429,
+)
 
-# 429 responses without a `Should-Wait` header use a zero wait, keeping the tests fast.
-RETRYABLE_STATUS_CODE = 429
+LOGGER_NAME = "ghga_service_commons.transports.retry"
+# A status code from the default retryable set (see RetryTransportConfig).
+RETRYABLE_STATUS_CODE = 503
+_REQUEST = httpx.Request("GET", "http://test")
 
 
-def _tracked_response(status_code: int) -> httpx.Response:
-    """Build a response whose ``aclose`` is wrapped so it can be asserted on."""
-    response = httpx.Response(status_code=status_code)
-    response.aclose = AsyncMock(wraps=response.aclose)  # type: ignore[method-assign]
-    return response
+class _TrackedResponse(httpx.Response):
+    """Response that records whether it was closed, to detect leaked connections."""
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__(status_code=status_code)
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+        await super().aclose()
 
 
-def _retry_transport(responses: list[httpx.Response]) -> AsyncRetryTransport:
-    """Wrap a mock transport that yields the given responses in turn."""
+def _no_wait(config: RetryTransportConfig) -> Callable[[RetryCallState], float]:
+    """Wait strategy injecting zero delay so retry behavior tests stay fast."""
+    return lambda retry_state: 0
+
+
+def _mock_transport(side_effect: list[object]) -> AsyncMock:
+    """Build a transport mock whose calls yield the given responses/exceptions in turn."""
     transport = AsyncMock(spec=httpx.AsyncBaseTransport)
-    transport.handle_async_request = AsyncMock(side_effect=responses)
+    transport.handle_async_request = AsyncMock(side_effect=side_effect)
+    return transport
+
+
+def _retry_transport(
+    transport: AsyncMock, *, num_retries: int = 3, reraise: bool = True
+) -> AsyncRetryTransport:
+    """Wrap the transport in a retry transport that does not actually wait between tries."""
     return AsyncRetryTransport(
-        config=RetryTransportConfig(client_num_retries=len(responses)),
+        config=RetryTransportConfig(
+            client_num_retries=num_retries,
+            client_reraise_from_retry_error=reraise,
+        ),
         transport=transport,
+        wait_strategy=_no_wait,
     )
+
+
+def _retry_state(
+    *,
+    result: httpx.Response | None = None,
+    exception: BaseException | None = None,
+    attempt_number: int = 1,
+    fn: Callable[..., object] | None = None,
+) -> RetryCallState:
+    """Construct a RetryCallState carrying the given outcome for strategy/logger tests."""
+    state = RetryCallState(AsyncRetrying(), fn=fn, args=(), kwargs={})
+    state.attempt_number = attempt_number
+    if exception is not None:
+        state.set_exception((type(exception), exception, exception.__traceback__))
+    elif result is not None:
+        state.set_result(result)
+    return state
+
+
+def _named_function() -> None:
+    """Stand-in wrapped function so loggers have a qualified name to report."""
+
+
+# --- retry behavior -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_first_successful_response():
+    """A non-retryable success is returned immediately without a second attempt."""
+    response = _TrackedResponse(httpx.codes.OK)
+    transport = _mock_transport([response])
+
+    result = await _retry_transport(transport).handle_async_request(_REQUEST)
+
+    assert result is response
+    assert transport.handle_async_request.await_count == 1
+    assert not response.closed
+
+
+@pytest.mark.asyncio
+async def test_retries_retryable_status_until_success():
+    """Retryable status codes are retried until a successful response is received."""
+    responses = [
+        _TrackedResponse(RETRYABLE_STATUS_CODE),
+        _TrackedResponse(RETRYABLE_STATUS_CODE),
+        _TrackedResponse(httpx.codes.OK),
+    ]
+    transport = _mock_transport(responses)  # type: ignore[arg-type]
+
+    result = await _retry_transport(transport).handle_async_request(_REQUEST)
+
+    assert result is responses[-1]
+    assert transport.handle_async_request.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_non_retryable_status():
+    """A non-retryable status code is returned as-is after a single attempt."""
+    response = _TrackedResponse(httpx.codes.NOT_FOUND)
+    transport = _mock_transport([response])
+
+    result = await _retry_transport(transport).handle_async_request(_REQUEST)
+
+    assert result is response
+    assert transport.handle_async_request.await_count == 1
+    assert not response.closed
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        httpx.ConnectTimeout("timeout"),
+        httpx.ConnectError("network"),
+        httpx.RemoteProtocolError("protocol"),
+        httpx.ProxyError("proxy"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_retries_on_retryable_exception(exception: Exception):
+    """Configured retryable exception types trigger a retry that can then succeed."""
+    response = _TrackedResponse(httpx.codes.OK)
+    transport = _mock_transport([exception, response])
+
+    result = await _retry_transport(transport).handle_async_request(_REQUEST)
+
+    assert result is response
+    assert transport.handle_async_request.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_unlisted_exception():
+    """An exception type outside the retryable set propagates without any retry."""
+    transport = _mock_transport([RuntimeError("boom")])
+
+    with pytest.raises(RuntimeError):
+        await _retry_transport(transport).handle_async_request(_REQUEST)
+
+    assert transport.handle_async_request.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reraises_original_exception_when_configured():
+    """With reraise enabled the original exception surfaces after retries are exhausted."""
+    transport = _mock_transport([httpx.ConnectError("c")] * 3)
+
+    with pytest.raises(httpx.ConnectError):
+        await _retry_transport(
+            transport, num_retries=3, reraise=True
+        ).handle_async_request(_REQUEST)
+
+    assert transport.handle_async_request.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_raises_retry_error_when_not_reraising():
+    """With reraise disabled the exhausted exception is wrapped in a RetryError."""
+    exception = httpx.ConnectError("c")
+    transport = _mock_transport([exception] * 3)
+
+    with pytest.raises(RetryError) as exc_info:
+        await _retry_transport(
+            transport, num_retries=3, reraise=False
+        ).handle_async_request(_REQUEST)
+
+    assert exc_info.value.last_attempt is not None
+    assert exc_info.value.last_attempt.exception() is exception
+    assert transport.handle_async_request.await_count == 3
+
+
+# --- connection handling across retries -----------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -53,20 +215,18 @@ async def test_retried_responses_are_closed():
     so all but the final, returned response must be closed to avoid leaking connections.
     """
     responses = [
-        _tracked_response(RETRYABLE_STATUS_CODE),
-        _tracked_response(RETRYABLE_STATUS_CODE),
-        _tracked_response(httpx.codes.OK),
+        _TrackedResponse(RETRYABLE_STATUS_CODE),
+        _TrackedResponse(RETRYABLE_STATUS_CODE),
+        _TrackedResponse(httpx.codes.OK),
     ]
-    retry_transport = _retry_transport(responses)
+    transport = _mock_transport(responses)  # type: ignore[arg-type]
 
-    result = await retry_transport.handle_async_request(
-        httpx.Request("GET", "http://test")
-    )
+    result = await _retry_transport(transport).handle_async_request(_REQUEST)
 
     *retried, returned = responses
     assert result is returned
-    assert all(response.aclose.called for response in retried)
-    assert not returned.aclose.called
+    assert all(response.closed for response in retried)
+    assert not returned.closed
 
 
 @pytest.mark.asyncio
@@ -76,10 +236,143 @@ async def test_exhausted_retries_close_last_response():
     A result-based exhaustion raises ``RetryError`` instead of returning the response,
     so that last response would also leak its connection if it were not closed.
     """
-    responses = [_tracked_response(RETRYABLE_STATUS_CODE) for _ in range(3)]
-    retry_transport = _retry_transport(responses)
+    responses = [_TrackedResponse(RETRYABLE_STATUS_CODE) for _ in range(3)]
+    transport = _mock_transport(responses)  # type: ignore[arg-type]
 
     with pytest.raises(RetryError):
-        await retry_transport.handle_async_request(httpx.Request("GET", "http://test"))
+        await _retry_transport(transport).handle_async_request(_REQUEST)
 
-    assert all(response.aclose.called for response in responses)
+    assert all(response.closed for response in responses)
+
+
+@pytest.mark.asyncio
+async def test_aclose_delegates_to_wrapped_transport():
+    """Closing the retry transport closes the transport it wraps."""
+    transport = _mock_transport([])
+
+    await _retry_transport(transport).aclose()
+
+    transport.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_closes_transport():
+    """Exiting the async context manager closes the wrapped transport."""
+    transport = _mock_transport([])
+
+    async with _retry_transport(transport) as retry_transport:
+        assert isinstance(retry_transport, AsyncRetryTransport)
+
+    transport.aclose.assert_awaited_once()
+
+
+# --- wait strategy --------------------------------------------------------------------
+
+
+def test_wait_strategy_ignores_429_without_should_wait():
+    """A 429 lacking the Should-Wait header skips the backoff entirely."""
+    wait = wait_exponential_ignore_429(max=60)
+    state = _retry_state(result=httpx.Response(429), attempt_number=3)
+
+    assert wait(state) == 0
+
+
+def test_wait_strategy_backs_off_for_429_with_should_wait():
+    """A 429 carrying the Should-Wait header falls back to exponential backoff."""
+    wait = wait_exponential_ignore_429(max=60)
+    state = _retry_state(
+        result=httpx.Response(429, headers={"Should-Wait": "true"}), attempt_number=2
+    )
+
+    assert wait(state) == 2  # 1 * 2 ** (2 - 1)
+
+
+def test_wait_strategy_backs_off_for_other_status():
+    """Non-429 responses use the regular exponential backoff."""
+    wait = wait_exponential_ignore_429(max=60)
+    state = _retry_state(result=httpx.Response(503), attempt_number=3)
+
+    assert wait(state) == 4  # 2 ** (3 - 1)
+
+
+def test_wait_strategy_caps_at_max():
+    """The computed backoff never exceeds the configured maximum."""
+    wait = wait_exponential_ignore_429(max=5)
+    state = _retry_state(result=httpx.Response(503), attempt_number=10)
+
+    assert wait(state) == 5
+
+
+def test_wait_strategy_handles_failed_outcome():
+    """A failed (exception) outcome is backed off without inspecting a result."""
+    wait = wait_exponential_ignore_429(max=60)
+    state = _retry_state(exception=httpx.ConnectError("boom"), attempt_number=1)
+
+    assert wait(state) == 1  # 2 ** (1 - 1)
+
+
+def test_default_wait_strategy_uses_configured_max():
+    """The default wait strategy honors the configured backoff maximum."""
+    wait = _default_wait_strategy(
+        RetryTransportConfig(client_exponential_backoff_max=42)
+    )
+
+    assert isinstance(wait, wait_exponential_ignore_429)
+    assert wait.max == 42
+
+
+def test_default_stop_strategy_uses_configured_retries():
+    """The default stop strategy stops after the configured number of attempts."""
+    stop = _default_stop_strategy(RetryTransportConfig(client_num_retries=7))
+
+    assert stop.max_attempt_number == 7
+
+
+# --- logging callbacks ----------------------------------------------------------------
+
+
+def test_log_before_attempt_records_attempt(caplog: pytest.LogCaptureFixture):
+    """The before-attempt logger emits the function name and attempt number."""
+    state = _retry_state(fn=_named_function, attempt_number=2)
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        _log_before_attempt(state)
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.attempt_number == 2  # type: ignore[attr-defined]
+    assert record.function_name == _named_function.__qualname__  # type: ignore[attr-defined]
+
+
+def test_log_before_attempt_without_function_logs_no_info(
+    caplog: pytest.LogCaptureFixture,
+):
+    """Without a wrapped function the before-attempt logger emits nothing at INFO."""
+    state = _retry_state(fn=None)
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        _log_before_attempt(state)
+
+    assert caplog.records == []
+
+
+def test_log_retry_stats_includes_response_status(caplog: pytest.LogCaptureFixture):
+    """For a response outcome the stats logger records the status code."""
+    state = _retry_state(fn=_named_function, result=httpx.Response(503))
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        _log_retry_stats(state)
+
+    assert caplog.records[0].response_status_code == 503  # type: ignore[attr-defined]
+
+
+def test_log_retry_stats_includes_exception_details(caplog: pytest.LogCaptureFixture):
+    """For a failed outcome the stats logger records the exception type and message."""
+    state = _retry_state(fn=_named_function, exception=httpx.ConnectError("boom"))
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        _log_retry_stats(state)
+
+    record = caplog.records[0]
+    assert record.exception_type is httpx.ConnectError  # type: ignore[attr-defined]
+    assert "boom" in record.exception_message  # type: ignore[attr-defined]

--- a/tests/unit/transports/test_retry.py
+++ b/tests/unit/transports/test_retry.py
@@ -26,15 +26,12 @@ from tenacity import AsyncRetrying, RetryCallState, RetryError
 from ghga_service_commons.transports.config import RetryTransportConfig
 from ghga_service_commons.transports.retry import (
     AsyncRetryTransport,
-    _default_stop_strategy,
-    _default_wait_strategy,
     _log_before_attempt,
     _log_retry_stats,
     wait_exponential_ignore_429,
 )
 
 LOGGER_NAME = "ghga_service_commons.transports.retry"
-# A status code from the default retryable set (see RetryTransportConfig).
 RETRYABLE_STATUS_CODE = 503
 _REQUEST = httpx.Request("GET", "http://test")
 
@@ -98,12 +95,9 @@ def _named_function() -> None:
     """Stand-in wrapped function so loggers have a qualified name to report."""
 
 
-# --- retry behavior -------------------------------------------------------------------
-
-
 @pytest.mark.asyncio
 async def test_returns_first_successful_response():
-    """A non-retryable success is returned immediately without a second attempt."""
+    """Ensure a non-retryable success is returned immediately without a second attempt."""
     response = _TrackedResponse(httpx.codes.OK)
     transport = _mock_transport([response])
 
@@ -116,7 +110,7 @@ async def test_returns_first_successful_response():
 
 @pytest.mark.asyncio
 async def test_retries_retryable_status_until_success():
-    """Retryable status codes are retried until a successful response is received."""
+    """Ensure retryable status codes are retried until a successful response is received."""
     responses = [
         _TrackedResponse(RETRYABLE_STATUS_CODE),
         _TrackedResponse(RETRYABLE_STATUS_CODE),
@@ -132,7 +126,7 @@ async def test_retries_retryable_status_until_success():
 
 @pytest.mark.asyncio
 async def test_does_not_retry_non_retryable_status():
-    """A non-retryable status code is returned as-is after a single attempt."""
+    """Ensure a non-retryable status code is returned as-is after a single attempt."""
     response = _TrackedResponse(httpx.codes.NOT_FOUND)
     transport = _mock_transport([response])
 
@@ -154,7 +148,7 @@ async def test_does_not_retry_non_retryable_status():
 )
 @pytest.mark.asyncio
 async def test_retries_on_retryable_exception(exception: Exception):
-    """Configured retryable exception types trigger a retry that can then succeed."""
+    """Ensure configured retryable exception types trigger a retry that can then succeed."""
     response = _TrackedResponse(httpx.codes.OK)
     transport = _mock_transport([exception, response])
 
@@ -166,7 +160,7 @@ async def test_retries_on_retryable_exception(exception: Exception):
 
 @pytest.mark.asyncio
 async def test_does_not_retry_unlisted_exception():
-    """An exception type outside the retryable set propagates without any retry."""
+    """Ensure an exception type outside the retryable set propagates without any retry."""
     transport = _mock_transport([RuntimeError("boom")])
 
     with pytest.raises(RuntimeError):
@@ -177,7 +171,7 @@ async def test_does_not_retry_unlisted_exception():
 
 @pytest.mark.asyncio
 async def test_reraises_original_exception_when_configured():
-    """With reraise enabled the original exception surfaces after retries are exhausted."""
+    """Ensure with reraise enabled the original exception surfaces after retries are exhausted."""
     transport = _mock_transport([httpx.ConnectError("c")] * 3)
 
     with pytest.raises(httpx.ConnectError):
@@ -190,7 +184,7 @@ async def test_reraises_original_exception_when_configured():
 
 @pytest.mark.asyncio
 async def test_raises_retry_error_when_not_reraising():
-    """With reraise disabled the exhausted exception is wrapped in a RetryError."""
+    """Ensure with reraise disabled the exhausted exception is wrapped in a RetryError."""
     exception = httpx.ConnectError("c")
     transport = _mock_transport([exception] * 3)
 
@@ -202,9 +196,6 @@ async def test_raises_retry_error_when_not_reraising():
     assert exc_info.value.last_attempt is not None
     assert exc_info.value.last_attempt.exception() is exception
     assert transport.handle_async_request.await_count == 3
-
-
-# --- connection handling across retries -----------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -231,11 +222,7 @@ async def test_retried_responses_are_closed():
 
 @pytest.mark.asyncio
 async def test_exhausted_retries_close_last_response():
-    """When retries are exhausted, the final unreturned response is closed too.
-
-    A result-based exhaustion raises ``RetryError`` instead of returning the response,
-    so that last response would also leak its connection if it were not closed.
-    """
+    """Ensure when retries are exhausted, the final unreturned response is closed."""
     responses = [_TrackedResponse(RETRYABLE_STATUS_CODE) for _ in range(3)]
     transport = _mock_transport(responses)  # type: ignore[arg-type]
 
@@ -247,7 +234,7 @@ async def test_exhausted_retries_close_last_response():
 
 @pytest.mark.asyncio
 async def test_aclose_delegates_to_wrapped_transport():
-    """Closing the retry transport closes the transport it wraps."""
+    """Ensure closing the retry transport closes the transport it wraps."""
     transport = _mock_transport([])
 
     await _retry_transport(transport).aclose()
@@ -257,7 +244,7 @@ async def test_aclose_delegates_to_wrapped_transport():
 
 @pytest.mark.asyncio
 async def test_async_context_manager_closes_transport():
-    """Exiting the async context manager closes the wrapped transport."""
+    """Ensure exiting the async context manager closes the wrapped transport."""
     transport = _mock_transport([])
 
     async with _retry_transport(transport) as retry_transport:
@@ -266,11 +253,8 @@ async def test_async_context_manager_closes_transport():
     transport.aclose.assert_awaited_once()
 
 
-# --- wait strategy --------------------------------------------------------------------
-
-
 def test_wait_strategy_ignores_429_without_should_wait():
-    """A 429 lacking the Should-Wait header skips the backoff entirely."""
+    """Ensure a 429 lacking the Should-Wait header skips the backoff entirely."""
     wait = wait_exponential_ignore_429(max=60)
     state = _retry_state(result=httpx.Response(429), attempt_number=3)
 
@@ -278,25 +262,25 @@ def test_wait_strategy_ignores_429_without_should_wait():
 
 
 def test_wait_strategy_backs_off_for_429_with_should_wait():
-    """A 429 carrying the Should-Wait header falls back to exponential backoff."""
+    """Ensure a 429 carrying the Should-Wait header falls back to exponential backoff."""
     wait = wait_exponential_ignore_429(max=60)
     state = _retry_state(
         result=httpx.Response(429, headers={"Should-Wait": "true"}), attempt_number=2
     )
 
-    assert wait(state) == 2  # 1 * 2 ** (2 - 1)
+    assert wait(state) == 2
 
 
 def test_wait_strategy_backs_off_for_other_status():
-    """Non-429 responses use the regular exponential backoff."""
+    """Ensure non-429 responses use the regular exponential backoff."""
     wait = wait_exponential_ignore_429(max=60)
     state = _retry_state(result=httpx.Response(503), attempt_number=3)
 
-    assert wait(state) == 4  # 2 ** (3 - 1)
+    assert wait(state) == 4
 
 
 def test_wait_strategy_caps_at_max():
-    """The computed backoff never exceeds the configured maximum."""
+    """Ensure the computed backoff never exceeds the configured maximum."""
     wait = wait_exponential_ignore_429(max=5)
     state = _retry_state(result=httpx.Response(503), attempt_number=10)
 
@@ -304,35 +288,15 @@ def test_wait_strategy_caps_at_max():
 
 
 def test_wait_strategy_handles_failed_outcome():
-    """A failed (exception) outcome is backed off without inspecting a result."""
+    """Ensure a failed outcome is backed off without inspecting a result."""
     wait = wait_exponential_ignore_429(max=60)
     state = _retry_state(exception=httpx.ConnectError("boom"), attempt_number=1)
 
-    assert wait(state) == 1  # 2 ** (1 - 1)
-
-
-def test_default_wait_strategy_uses_configured_max():
-    """The default wait strategy honors the configured backoff maximum."""
-    wait = _default_wait_strategy(
-        RetryTransportConfig(client_exponential_backoff_max=42)
-    )
-
-    assert isinstance(wait, wait_exponential_ignore_429)
-    assert wait.max == 42
-
-
-def test_default_stop_strategy_uses_configured_retries():
-    """The default stop strategy stops after the configured number of attempts."""
-    stop = _default_stop_strategy(RetryTransportConfig(client_num_retries=7))
-
-    assert stop.max_attempt_number == 7
-
-
-# --- logging callbacks ----------------------------------------------------------------
+    assert wait(state) == 1
 
 
 def test_log_before_attempt_records_attempt(caplog: pytest.LogCaptureFixture):
-    """The before-attempt logger emits the function name and attempt number."""
+    """Ensure the before-attempt logger emits the function name and attempt number."""
     state = _retry_state(fn=_named_function, attempt_number=2)
 
     with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
@@ -344,20 +308,8 @@ def test_log_before_attempt_records_attempt(caplog: pytest.LogCaptureFixture):
     assert record.function_name == _named_function.__qualname__  # type: ignore[attr-defined]
 
 
-def test_log_before_attempt_without_function_logs_no_info(
-    caplog: pytest.LogCaptureFixture,
-):
-    """Without a wrapped function the before-attempt logger emits nothing at INFO."""
-    state = _retry_state(fn=None)
-
-    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
-        _log_before_attempt(state)
-
-    assert caplog.records == []
-
-
 def test_log_retry_stats_includes_response_status(caplog: pytest.LogCaptureFixture):
-    """For a response outcome the stats logger records the status code."""
+    """Ensure that for a response outcome the stats logger records the status code."""
     state = _retry_state(fn=_named_function, result=httpx.Response(503))
 
     with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
@@ -367,7 +319,7 @@ def test_log_retry_stats_includes_response_status(caplog: pytest.LogCaptureFixtu
 
 
 def test_log_retry_stats_includes_exception_details(caplog: pytest.LogCaptureFixture):
-    """For a failed outcome the stats logger records the exception type and message."""
+    """Ensure that for a failed outcome the stats logger records the exception type and message."""
     state = _retry_state(fn=_named_function, exception=httpx.ConnectError("boom"))
 
     with caplog.at_level(logging.INFO, logger=LOGGER_NAME):

--- a/tests/unit/transports/test_retry.py
+++ b/tests/unit/transports/test_retry.py
@@ -1,0 +1,85 @@
+# Copyright 2021 - 2026 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the retry transport, focusing on connection handling across retries."""
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from tenacity import RetryError
+
+from ghga_service_commons.transports.config import RetryTransportConfig
+from ghga_service_commons.transports.retry import AsyncRetryTransport
+
+# 429 responses without a `Should-Wait` header use a zero wait, keeping the tests fast.
+RETRYABLE_STATUS_CODE = 429
+
+
+def _tracked_response(status_code: int) -> httpx.Response:
+    """Build a response whose ``aclose`` is wrapped so it can be asserted on."""
+    response = httpx.Response(status_code=status_code)
+    response.aclose = AsyncMock(wraps=response.aclose)  # type: ignore[method-assign]
+    return response
+
+
+def _retry_transport(responses: list[httpx.Response]) -> AsyncRetryTransport:
+    """Wrap a mock transport that yields the given responses in turn."""
+    transport = AsyncMock(spec=httpx.AsyncBaseTransport)
+    transport.handle_async_request = AsyncMock(side_effect=responses)
+    return AsyncRetryTransport(
+        config=RetryTransportConfig(client_num_retries=len(responses)),
+        transport=transport,
+    )
+
+
+@pytest.mark.asyncio
+async def test_retried_responses_are_closed():
+    """Ensure discarded responses from retried attempts are closed, the returned one is not.
+
+    Each retried response holds a connection from the pool until it is read or closed,
+    so all but the final, returned response must be closed to avoid leaking connections.
+    """
+    responses = [
+        _tracked_response(RETRYABLE_STATUS_CODE),
+        _tracked_response(RETRYABLE_STATUS_CODE),
+        _tracked_response(httpx.codes.OK),
+    ]
+    retry_transport = _retry_transport(responses)
+
+    result = await retry_transport.handle_async_request(
+        httpx.Request("GET", "http://test")
+    )
+
+    *retried, returned = responses
+    assert result is returned
+    assert all(response.aclose.called for response in retried)
+    assert not returned.aclose.called
+
+
+@pytest.mark.asyncio
+async def test_exhausted_retries_close_last_response():
+    """When retries are exhausted, the final unreturned response is closed too.
+
+    A result-based exhaustion raises ``RetryError`` instead of returning the response,
+    so that last response would also leak its connection if it were not closed.
+    """
+    responses = [_tracked_response(RETRYABLE_STATUS_CODE) for _ in range(3)]
+    retry_transport = _retry_transport(responses)
+
+    with pytest.raises(RetryError):
+        await retry_transport.handle_async_request(httpx.Request("GET", "http://test"))
+
+    assert all(response.aclose.called for response in responses)

--- a/tests/unit/transports/test_retry.py
+++ b/tests/unit/transports/test_retry.py
@@ -48,6 +48,21 @@ class _TrackedResponse(httpx.Response):
         await super().aclose()
 
 
+class _FailingCloseResponse(httpx.Response):
+    """Response whose aclose() always raises, to exercise cleanup error handling.
+
+    Counts close calls so tests can assert the same response is not closed twice.
+    """
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__(status_code=status_code)
+        self.close_calls = 0
+
+    async def aclose(self) -> None:
+        self.close_calls += 1
+        raise RuntimeError("aclose failed")
+
+
 def _no_wait(config: RetryTransportConfig) -> Callable[[RetryCallState], float]:
     """Wait strategy injecting zero delay so retry behavior tests stay fast."""
     return lambda retry_state: 0
@@ -230,6 +245,32 @@ async def test_exhausted_retries_close_last_response():
         await _retry_transport(transport).handle_async_request(_REQUEST)
 
     assert all(response.closed for response in responses)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_close_error_does_not_mask_original_exception():
+    """Ensure a failing aclose() during cleanup does not replace the underlying exception."""
+    responses = [
+        _TrackedResponse(RETRYABLE_STATUS_CODE),
+        _TrackedResponse(RETRYABLE_STATUS_CODE),
+        _FailingCloseResponse(RETRYABLE_STATUS_CODE),
+    ]
+    transport = _mock_transport(responses)  # type: ignore[arg-type]
+
+    with pytest.raises(RetryError):
+        await _retry_transport(transport).handle_async_request(_REQUEST)
+
+
+@pytest.mark.asyncio
+async def test_pre_attempt_close_error_clears_latest_response():
+    """Ensure a failing pre-attempt aclose() clears the reference so it is not closed twice."""
+    failing = _FailingCloseResponse(RETRYABLE_STATUS_CODE)
+    transport = _mock_transport([failing])
+
+    with pytest.raises(RuntimeError):
+        await _retry_transport(transport).handle_async_request(_REQUEST)
+
+    assert failing.close_calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR improves some existing logic in the retry transport layer and introduces more logging for better visibility:

1) `_log_before_attempt` now produces separate log messages, so we still get some info about the attempt even if something goes wrong with the `stats_logger`
2) `_log_retry_stats` no longer directly mutates the underlying state, but operates on its own copy
3) `retry_state.outcome.result` is no longer called directly, as to not reraise and pollute the traceback even though it's actually handled at the points it appeared in the traceback before (in `_log_retry_stats` and `__call__`)
4) Underlying connections are now correctly freed when retrying due to a status code.

~~Patch version has been bumped by a previous PR~~