### PR TITLE
Switch to httpx2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, dev, --branch, int, --branch, main]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.0
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/.pyproject_generation/pyproject_custom.toml
+++ b/.pyproject_generation/pyproject_custom.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ghga_service_commons"
-version = "7.1.0"
+version = "8.0.0"
 description = "A library that contains common functionality used in services of GHGA"
 readme = "README.md"
 authors = [
@@ -14,13 +14,12 @@ api = [
     "uvicorn[standard]>=0.40, <1",
     "ghga-service-commons[http,objectstorage]",
 ]
-http = ["httpx>=0.28, <0.29"]
+http = ["httpx2>=2.9.1, <3"]
 auth = ["jwcrypto>=1.5.6, <2", "pydantic[email]>=2, <3"]
 crypt = ["pynacl>=1.6.2, <2", "crypt4gh>=1.8.6, <2"]
 dev = ["requests>=2.32, <3"]
 objectstorage = ["hexkit[s3]>=8"]
 transports = [
-    "hishel[async]>=1.1.8, <2",
     "tenacity >=9.1.2, <10",
     "ghga-service-commons[http]",
 ]

--- a/lock/requirements-dev-template.in
+++ b/lock/requirements-dev-template.in
@@ -15,8 +15,7 @@ ruff>=0.14.14
 click>=8.3
 typer>=0.21.1
 
-httpx>=0.28.1
-pytest-httpx>=0.36
+httpx2>=2.9.1
 
 urllib3>=2.6.3
 requests>=2.32.5

--- a/lock/requirements-dev.txt
+++ b/lock/requirements-dev.txt
@@ -4,23 +4,17 @@ annotated-doc==0.0.4 \
     # via
     #   fastapi
     #   typer
-annotated-types==0.7.0 \
-    --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
-    --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
+annotated-types==0.8.0 \
+    --hash=sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7 \
+    --hash=sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0
     # via pydantic
 anyio==4.14.2 \
     --hash=sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494 \
     --hash=sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f
     # via
-    #   anysqlite
-    #   hishel
-    #   httpx
+    #   httpx2
     #   starlette
     #   watchfiles
-anysqlite==0.0.5 \
-    --hash=sha256:9dfcf87baf6b93426ad1d9118088c41dbf24ef01b445eea4a5d486bac2755cce \
-    --hash=sha256:cb345dc4f76f6b37f768d7a0b3e9cf5c700dfcb7a6356af8ab46a11f666edbe7
-    # via hishel
 ast-serialize==0.6.0 \
     --hash=sha256:0067b25fce104eaae5b88383de9ab803faeb671831e14ca698b771b356e2600f \
     --hash=sha256:085de7f62dc9cc247eb01e965a362707d1d90b1d89a82c5bf78301a60a3c417b \
@@ -126,32 +120,29 @@ bcrypt==5.0.0 \
     --hash=sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822 \
     --hash=sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b
     # via crypt4gh
-boto3==1.43.51 \
-    --hash=sha256:a97057bb609fd38c80448db6a93db770786775dabd651401debf09816d4553d7 \
-    --hash=sha256:b5a416cc703db73b69b22bef563c89c1fb14a4b10a93628d3c7abc4dd1aaf979
+boto3==1.43.56 \
+    --hash=sha256:57c90df9fb026f2e6ae22530861198130203733c5c9ec4e5cca3a4037f5a8db4 \
+    --hash=sha256:feb699d4ab241ef5c1b80bb58277be2aaad365cd4b672d7817e0bc59ee45131b
     # via hexkit
-botocore==1.43.51 \
-    --hash=sha256:7c2c538c932bddc95834e177ce6f91dcc388c6a7934b4f8d0db13caa30e3e543 \
-    --hash=sha256:e0e5e88585fdb01dcb6b533ac2dd3f18d5d45092a14ccbfd330e3576a4152128
+botocore==1.43.56 \
+    --hash=sha256:6c01f85f0ff9863076f4c761e74ee3aa96c5ccc1ad09fc1efd62ef8f2d22bf57 \
+    --hash=sha256:aafc741f1b10f6fd63253eaf6ea029680c1ff436d87e1b8969d62aefa0c76976
     # via
     #   boto3
     #   hexkit
     #   s3transfer
-cachetools==7.1.4 \
-    --hash=sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54 \
-    --hash=sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6
+cachetools==7.1.6 \
+    --hash=sha256:2c12e255780330af28b91bb7fb96cce4c766f04e38396b9a24510190a5827096 \
+    --hash=sha256:c7a79e7f30ba9943c1cefd08cc36f006aaae086e017af9166f1d59d6170c47e1
     # via tox
 casefy==1.1.0 \
     --hash=sha256:849d6e0f80506fac70ab8e18999a4ca1eb7d8f70941682383d64aa22a7497f8f \
     --hash=sha256:a3dfcb14d85902d90702db1e9835760237f6a73ec0ae3b7e991ad767513a3cbc
     # via -r lock/requirements-dev-template.in
-certifi==2026.6.17 \
-    --hash=sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432 \
-    --hash=sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db
-    # via
-    #   httpcore
-    #   httpx
-    #   requests
+certifi==2026.7.22 \
+    --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775 \
+    --hash=sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55
+    # via requests
 cffi==2.1.0 \
     --hash=sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc \
     --hash=sha256:03e9810d18c646077e501f661b682fbf5dee4676048527ca3cffe66faa9960dd \
@@ -569,13 +560,13 @@ email-validator==2.3.0 \
     --hash=sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4 \
     --hash=sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426
     # via pydantic
-fastapi==0.139.2 \
-    --hash=sha256:333145a6891e9b5b3cfceb69baf817e8240cde4d4588ae5a10bf56ffacb6255e \
-    --hash=sha256:b9ad015a835173d59865e2f5d8296fbc2b317bf56a2ba1a5bfbdd03de2fd4b1c
+fastapi==0.140.0 \
+    --hash=sha256:e951c0a0d9540bf5d9a2a9e078fd415da2ab7e312d435139e7d9e2e7fe9f0b23 \
+    --hash=sha256:f338951b82fd74ca8f843163aec43ea1a1ce84d515415a50fa98fa25572a5544
     # via ghga-service-commons (pyproject.toml)
-filelock==3.31.1 \
-    --hash=sha256:9e0c4e88ebe90833c1beafd3a547ccbc0bf7f491cd3858c3ec7aed63efe02163 \
-    --hash=sha256:9ea33146c780161bf67cb20c7cb26b651566820d65ad8dfdd79422602a2dcfc0
+filelock==3.32.0 \
+    --hash=sha256:7be2ad23a14607ccc71808e68fe30848aeace7058ace17852f68e2a68e310402 \
+    --hash=sha256:d396bea984af47333ef05e50eae7eff88c84256de6112aea0ec48a233c064fe3
     # via
     #   python-discovery
     #   tox
@@ -584,20 +575,16 @@ h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
     --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
     # via
-    #   httpcore
+    #   httpcore2
     #   uvicorn
-hexkit==8.5.0 \
-    --hash=sha256:010effde769416dafc5782383772310f056370f9408b5435e66140109e93f6ab \
-    --hash=sha256:5d781a01e11d9737b076bc4a1d24b19f1ad45c879eae141fdc8258b8feea8e3c
+hexkit==8.6.0 \
+    --hash=sha256:fa27d6151e3a888ab401124a040bcb40ac3d0c69d63d14727f10795bf97947be \
+    --hash=sha256:faecfc22e3b9ccb9ad3015aae4345468c7c40d2a40f1b1af2a4b4e9c9b759ded
     # via ghga-service-commons (pyproject.toml)
-hishel==1.3.0 \
-    --hash=sha256:5be585dca8c035866cffc745a50dbce6b277a3d1f4b07ef24f77c07f6b31ff92 \
-    --hash=sha256:b803ad9f1d410085b61459a5dbbd273806215021e672198ba911c7d3db14adaa
-    # via ghga-service-commons (pyproject.toml)
-httpcore==1.0.9 \
-    --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \
-    --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8
-    # via httpx
+httpcore2==2.9.1 \
+    --hash=sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2 \
+    --hash=sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26
+    # via httpx2
 httptools==0.8.0 \
     --hash=sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683 \
     --hash=sha256:0ea897f0c729581ebf72131a438a7932d9b14efef72d75ada966700cac3caaeb \
@@ -650,13 +637,12 @@ httptools==0.8.0 \
     --hash=sha256:f256d6ce930c52ca1cb2a960b7da03548c454e7d28b06059ad41bfe789036ce0 \
     --hash=sha256:fe2a4c95aeba2209434e7b31172da572846cae8ca0bf1e7013e61b99fbbf5e72
     # via uvicorn
-httpx==0.28.1 \
-    --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
-    --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
+httpx2==2.9.1 \
+    --hash=sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a \
+    --hash=sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a
     # via
     #   -r lock/requirements-dev-template.in
     #   ghga-service-commons (pyproject.toml)
-    #   pytest-httpx
 identify==2.6.19 \
     --hash=sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a \
     --hash=sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842
@@ -667,7 +653,7 @@ idna==3.18 \
     # via
     #   anyio
     #   email-validator
-    #   httpx
+    #   httpx2
     #   requests
 iniconfig==2.3.0 \
     --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
@@ -797,74 +783,6 @@ mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
     --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
     # via markdown-it-py
-msgpack==1.2.1 \
-    --hash=sha256:01e2dd6c9b19d333a00282330cc8a73d38d8dabc306dc5b42cd668c3ac82e833 \
-    --hash=sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a \
-    --hash=sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647 \
-    --hash=sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d \
-    --hash=sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064 \
-    --hash=sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107 \
-    --hash=sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac \
-    --hash=sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720 \
-    --hash=sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c \
-    --hash=sha256:146ee4e9ce80b365c6d4c47073da9da7bcec473e58194ceee5dd7620ace77e06 \
-    --hash=sha256:1548006a91aa93c5da81f3bdcebc1a0d10cea2d25969754fbe848da622b2b895 \
-    --hash=sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde \
-    --hash=sha256:1dabedcd0f23559f3596428c6589c1cd8c6eaed3a0d720795b07b0225d769203 \
-    --hash=sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc \
-    --hash=sha256:298872ecf9e61950f1c6af4ca969b859ee91783bb920ef6e6172697d0c8aad74 \
-    --hash=sha256:29a3f6e9667868429d8240dfd063ea5ffdc1321c13d783aa23827a38de0dcb22 \
-    --hash=sha256:2eda0b7ebb1283a98d3e4492ac933c8af6aff59fd3df1c3ed024f536af4b1dc8 \
-    --hash=sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35 \
-    --hash=sha256:2ff164c1b0bcb740b073b99e945234d0212852fa378e44a208c425379140dbeb \
-    --hash=sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9 \
-    --hash=sha256:350cb813d0af6e65d2f7ef0d729f7ff5be5a8bce03665892f43e5883d4ecc1b8 \
-    --hash=sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6 \
-    --hash=sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07 \
-    --hash=sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056 \
-    --hash=sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4 \
-    --hash=sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7 \
-    --hash=sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1 \
-    --hash=sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24 \
-    --hash=sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355 \
-    --hash=sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0 \
-    --hash=sha256:633727297ed063441fd1cda2288865487f33ad14eeb8831afb5f0c396a62cfce \
-    --hash=sha256:67f6dd22fa72a93752643f07889796d62739a13415ee630169a8ce764f86cf9f \
-    --hash=sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707 \
-    --hash=sha256:6ee967f7c7e1df2890c671ff2ee51a28ded0efc95da3e507176dee881ce36c66 \
-    --hash=sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b \
-    --hash=sha256:779197a6513bab3c3632265e3d0f7cb3227e62510841a6f34f1eaa37efbb345e \
-    --hash=sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d \
-    --hash=sha256:7d31c0ac0c640f877804c67cb2bc9f4e23dc2db97e96c2e67fa27d38283b41f8 \
-    --hash=sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7 \
-    --hash=sha256:83efa1c898e0fc5380fc0cabbf75164c52e3b5cbb45973710d75821928380c73 \
-    --hash=sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402 \
-    --hash=sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a \
-    --hash=sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d \
-    --hash=sha256:8c7b398c56ff125feae96c2737abfec5595f1fa0aa186df60c56040b8accb95c \
-    --hash=sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273 \
-    --hash=sha256:8ff92d7feeaf5bc26c51495b69e2f99ed97ab79346fb6555f44be7dd2ac6503b \
-    --hash=sha256:91054a783328e0ea7954b8771095705c8d2243b814743fbaadf14552c9c52c5d \
-    --hash=sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb \
-    --hash=sha256:a28d076ca7c82b9c8728ad90b7147489449557038bed50e4241eb832395169b4 \
-    --hash=sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190 \
-    --hash=sha256:aded5bdf32609dc7987a49bbbd15a8ef096193f96dd8bbeb791de729e650acf5 \
-    --hash=sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a \
-    --hash=sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7 \
-    --hash=sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1 \
-    --hash=sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889 \
-    --hash=sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c \
-    --hash=sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155 \
-    --hash=sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24 \
-    --hash=sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6 \
-    --hash=sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1 \
-    --hash=sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d \
-    --hash=sha256:ee1d9ed27d0497b848923746cf762ed2e7db24f4be7eec8e5cbe8c766aa707b7 \
-    --hash=sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64 \
-    --hash=sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2 \
-    --hash=sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc \
-    --hash=sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c
-    # via hishel
 mypy==2.3.0 \
     --hash=sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491 \
     --hash=sha256:094af99f92638aa92852326188b85a89e50f4a472f44827c03362228482f0762 \
@@ -935,9 +853,9 @@ pathspec==1.1.1 \
     --hash=sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a \
     --hash=sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189
     # via mypy
-platformdirs==4.10.1 \
-    --hash=sha256:0e4eff26be2d75293977f7cddc153fd9b8eaa7fb0c7b64ffe4076cb443117443 \
-    --hash=sha256:ceab4084426fe6319ce18e86deada8ab1b7487c7aee7040c55e277c9ae793695
+platformdirs==4.11.0 \
+    --hash=sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0 \
+    --hash=sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74
     # via
     #   python-discovery
     #   tox
@@ -949,9 +867,9 @@ pluggy==1.6.0 \
     #   pytest
     #   pytest-cov
     #   tox
-pre-commit==4.6.0 \
-    --hash=sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9 \
-    --hash=sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b
+pre-commit==4.6.1 \
+    --hash=sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421 \
+    --hash=sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717
     # via -r lock/requirements-dev-template.in
 pycparser==3.0 \
     --hash=sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29 \
@@ -1124,9 +1042,9 @@ pynacl==1.6.2 \
     --hash=sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2 \
     --hash=sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9
     # via ghga-service-commons (pyproject.toml)
-pyproject-api==1.10.1 \
-    --hash=sha256:c2b2726bd7aa9217b6c50b621fef5b2ae5def4d55b779c9e0694c15e0a8517ba \
-    --hash=sha256:fa9e6f66c35b5017e909825d8f2b5d5482ea699d7be809d21c03bd1f7317f36a
+pyproject-api==1.11.0 \
+    --hash=sha256:860060c8832dce983b5eec6f41c4c43eb3ec06ff7332387a63acdf5ca27b68d8 \
+    --hash=sha256:b8807d85a293e6c9f133e6575946fed45f1d42b22d58c780b33aa2421a799549
     # via tox
 pytest==9.1.1 \
     --hash=sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313 \
@@ -1135,7 +1053,6 @@ pytest==9.1.1 \
     #   -r lock/requirements-dev-template.in
     #   pytest-asyncio
     #   pytest-cov
-    #   pytest-httpx
 pytest-asyncio==1.4.0 \
     --hash=sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1 \
     --hash=sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42
@@ -1144,17 +1061,13 @@ pytest-cov==7.1.0 \
     --hash=sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2 \
     --hash=sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678
     # via -r lock/requirements-dev-template.in
-pytest-httpx==0.36.2 \
-    --hash=sha256:05a56527484f7f4e8c856419ea379b8dc359c36801c4992fdb330f294c690356 \
-    --hash=sha256:d42ebd5679442dc7bfb0c48e0767b6562e9bc4534d805127b0084171886a5e22
-    # via -r lock/requirements-dev-template.in
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
     # via botocore
-python-discovery==1.4.4 \
-    --hash=sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3 \
-    --hash=sha256:abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe
+python-discovery==1.5.0 \
+    --hash=sha256:3e014c6327154d3dda27939a9a0dc9c5c000439f1906d3f303b48f984bd2ecef \
+    --hash=sha256:70c4fc61b4e7404e44f01d6fc44a715c4d685ca6cea83d295922f05891877c98
     # via
     #   tox
     #   virtualenv
@@ -1253,29 +1166,29 @@ rich==15.0.0 \
     --hash=sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb \
     --hash=sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36
     # via typer
-ruff==0.15.22 \
-    --hash=sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f \
-    --hash=sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296 \
-    --hash=sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e \
-    --hash=sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c \
-    --hash=sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb \
-    --hash=sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809 \
-    --hash=sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8 \
-    --hash=sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224 \
-    --hash=sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64 \
-    --hash=sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178 \
-    --hash=sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576 \
-    --hash=sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde \
-    --hash=sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262 \
-    --hash=sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697 \
-    --hash=sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661 \
-    --hash=sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf \
-    --hash=sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a \
-    --hash=sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74
+ruff==0.16.0 \
+    --hash=sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17 \
+    --hash=sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d \
+    --hash=sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af \
+    --hash=sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09 \
+    --hash=sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522 \
+    --hash=sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472 \
+    --hash=sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0 \
+    --hash=sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b \
+    --hash=sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9 \
+    --hash=sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213 \
+    --hash=sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb \
+    --hash=sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed \
+    --hash=sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717 \
+    --hash=sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a \
+    --hash=sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81 \
+    --hash=sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982 \
+    --hash=sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e \
+    --hash=sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4
     # via -r lock/requirements-dev-template.in
-s3transfer==0.19.1 \
-    --hash=sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3 \
-    --hash=sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de
+s3transfer==0.19.2 \
+    --hash=sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993 \
+    --hash=sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25
     # via boto3
 setuptools==83.0.0 \
     --hash=sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef \
@@ -1319,10 +1232,16 @@ tornado==6.5.7 \
     --hash=sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4 \
     --hash=sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796
     # via snakeviz
-tox==4.57.0 \
-    --hash=sha256:b2f758011dfbad7be4b4cc39d2cae21deeb3c3c186e6d7a92d7630eade4218cf \
-    --hash=sha256:ede907fa911b55cbf1e7dc823a5b455a164755a172124675b811210676ba31c2
+tox==4.58.0 \
+    --hash=sha256:ab0b126a04dd56bc18e6d216386db09335247f2289b54cf534deb5c4ae3a8d2e \
+    --hash=sha256:dcae21f5f015f3a67658e35644cce0d1aa0dedcd06f3927f95d84e1717f6cea5
     # via -r lock/requirements-dev.in
+truststore==0.10.4 \
+    --hash=sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301 \
+    --hash=sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981
+    # via
+    #   httpcore2
+    #   httpx2
 typer==0.27.0 \
     --hash=sha256:629bd12ea5d13a17148125d9a264f949eb171fb3f120f9b04d85873cab054fa5 \
     --hash=sha256:6f4b27631e47f077871b7dc30e933ec0131c1390fbe0e387ea5574b5bac9ccf1
@@ -1332,7 +1251,6 @@ typing-extensions==4.16.0 \
     --hash=sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5
     # via
     #   fastapi
-    #   hishel
     #   jwcrypto
     #   mypy
     #   opentelemetry-api
@@ -1353,26 +1271,26 @@ urllib3==2.7.0 \
     #   -r lock/requirements-dev-template.in
     #   botocore
     #   requests
-uv==0.11.29 \
-    --hash=sha256:0222a51972e42bc1c132761ea027b9086d710ff5fa5199af658955bd03bee4d8 \
-    --hash=sha256:157ed0bcfef5aba9b53ff4b322e009b3261d83fbf5d9423e367a33c0416c85ac \
-    --hash=sha256:257c6df4393116114f296f7a02f51db9a2117f68c3ae93bbe218fa79e6521df3 \
-    --hash=sha256:2b49e175bfbcd8ac1e09e06f0b9d544b9e671d2cdecf753aa3fbff4d61d19317 \
-    --hash=sha256:2dc8012a693b6bb9ec17dcb2c2345cf273ccad06ae2ab4a8c7a0833955812c75 \
-    --hash=sha256:606e2bc7880d70448ff4359faa43a7c71743283010262fc142e1ca9fcb6937cf \
-    --hash=sha256:60e792b00f4cd6c5eadd814161cd046fa8418d83621d85d3e65aae28dc5b53ff \
-    --hash=sha256:66b250d102f0e49f3d2306353aaabb43f39da5ccfa4e84fe10ba8a25de85316c \
-    --hash=sha256:7711c46452b44332352d344b5818ad8faf04596efaf837d8114aa9984e4a9610 \
-    --hash=sha256:7d618b4a2ae2b367d20710858838344604d5b9e8c0863343d5f793142408ea11 \
-    --hash=sha256:865f09f5de0c1913bf9ed424bcc5c1a15780d01debd4d62b8a22c8f3e9bdb420 \
-    --hash=sha256:91b5d1407ac8757e1757268e9d983e9e7b72eeb826808f9e2404344a6de1d3fb \
-    --hash=sha256:a4ca34dc3b247740e511ca7c718181d5300e7899bbef755db45bb6c993610a64 \
-    --hash=sha256:aa166ce529cfbce6b3afaabdc4cdbfdf9e3e3d82413c709d679ff374eb76d5e9 \
-    --hash=sha256:abc641b24be42dc5d62f63ecb3500c07a0fb3c596e407963708f59114f0816ad \
-    --hash=sha256:db119a3ec9d7ce42e98de3d014427d74fd92f1f7c40fc9dfe62b14601a9e83da \
-    --hash=sha256:e245e6f95f154ae56793bfc7742ec27334a546469bba4d09c03624470ab451d2 \
-    --hash=sha256:eec03a8b63d55915694db3af4e91324b39ced49e2aeac7af37851c7eb3f470ea \
-    --hash=sha256:f7e4c709397468264764f571003fd278cbd384321f5c497370c28352bdb8b6a9
+uv==0.11.32 \
+    --hash=sha256:07ffc8322ce88b29dc0a905c102ea7d32c9021ee0353b641674e350c65fa930a \
+    --hash=sha256:125c142363d0842c8506a057da56bae182e2aa3957344f57dd9ef20ea10f06b0 \
+    --hash=sha256:19fb9f2dba53851c0ee6e7e5582bd355fcaa9b1387b5d688f5bb9efc543dc605 \
+    --hash=sha256:26d61d1b640d2dcfd7c3b64e75ada14c8eb477accba57f414c1a3759d6ab2253 \
+    --hash=sha256:2a56d1abf16337350e878b2c869b256b8448ecc4a722b98f8d41e1b3680a587b \
+    --hash=sha256:3da76cd4e2697de30928b8a8524bd39183ac1e08cb7e72833807c022b7cba6c4 \
+    --hash=sha256:43360834111ae917808a70b36f4fb0e53de8e0be422e4cd4445876ffae8decc2 \
+    --hash=sha256:5359a7b0de78ba99b2519d33c173e004c39111c4baebe1b7c3d111a2de2011e1 \
+    --hash=sha256:77f4356548ee8dc47efae154efd4e930c65570e7d4971c57bdef592f6eefb39c \
+    --hash=sha256:855632ee1d2a8491986efa54c562b806cd32477761889a1e13624b519d98a45e \
+    --hash=sha256:8e36fe8ff79ab7d13e9ad45d24bb9a52c1024caa6897cf62933bb3f760643d13 \
+    --hash=sha256:96625d832fe5b94ed0a029764cef0879ff47e3a525aec5c99d360a959e2f4aea \
+    --hash=sha256:bb1ae8189e315499a77f3cc27cac5985ab1d8cb79baa82e368b6c1e574a7d9cf \
+    --hash=sha256:be0799f1ad70c755d10de5aaf46af94199d4f16a992f90278f2662350cd3f4fe \
+    --hash=sha256:bf988bf510772785eac1edfc7cdedca074e8936b45e755b58f7f3e1e9ca86424 \
+    --hash=sha256:c82954b1bd507e767b1d996c2865ea3eb7d464a479ec0e4d60f0b8e2e07dee45 \
+    --hash=sha256:cd085addb35f074561d2c5659a088f5f10361502bd3ad4c8f5105f5a4b9d2817 \
+    --hash=sha256:f35b3b8b65ba4579f8b23645a19394f7e5f90b20b07376ecff18b3bb656a81ae \
+    --hash=sha256:f6f030a91a94655af11e41dafe1b41e1a90e1f2641bf13ff7ed7d4f5fb4f031d
     # via -r lock/requirements-dev-template.in
 uvicorn==0.51.0 \
     --hash=sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b \
@@ -1429,9 +1347,9 @@ uvloop==0.22.1 \
     --hash=sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c \
     --hash=sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42
     # via uvicorn
-virtualenv==21.6.1 \
-    --hash=sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128 \
-    --hash=sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b
+virtualenv==21.7.0 \
+    --hash=sha256:7f9519b9432ff11b6e1a3e94061664efc2ff99ea21780e3cf4f6bd0a5da8b37c \
+    --hash=sha256:a8370c1c5530fbabf955e40b8fbbc68a431648b10f9433faa587db30a06e51dd
     # via
     #   pre-commit
     #   tox

--- a/lock/requirements.txt
+++ b/lock/requirements.txt
@@ -4,9 +4,9 @@ annotated-doc==0.0.4 \
     # via
     #   -c lock/requirements-dev.txt
     #   fastapi
-annotated-types==0.7.0 \
-    --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
-    --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
+annotated-types==0.8.0 \
+    --hash=sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7 \
+    --hash=sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0
     # via
     #   -c lock/requirements-dev.txt
     #   pydantic
@@ -15,17 +15,9 @@ anyio==4.14.2 \
     --hash=sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f
     # via
     #   -c lock/requirements-dev.txt
-    #   anysqlite
-    #   hishel
-    #   httpx
+    #   httpx2
     #   starlette
     #   watchfiles
-anysqlite==0.0.5 \
-    --hash=sha256:9dfcf87baf6b93426ad1d9118088c41dbf24ef01b445eea4a5d486bac2755cce \
-    --hash=sha256:cb345dc4f76f6b37f768d7a0b3e9cf5c700dfcb7a6356af8ab46a11f666edbe7
-    # via
-    #   -c lock/requirements-dev.txt
-    #   hishel
 bcrypt==5.0.0 \
     --hash=sha256:046ad6db88edb3c5ece4369af997938fb1c19d6a699b9c1b27b0db432faae4c4 \
     --hash=sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a \
@@ -93,27 +85,25 @@ bcrypt==5.0.0 \
     # via
     #   -c lock/requirements-dev.txt
     #   crypt4gh
-boto3==1.43.51 \
-    --hash=sha256:a97057bb609fd38c80448db6a93db770786775dabd651401debf09816d4553d7 \
-    --hash=sha256:b5a416cc703db73b69b22bef563c89c1fb14a4b10a93628d3c7abc4dd1aaf979
+boto3==1.43.56 \
+    --hash=sha256:57c90df9fb026f2e6ae22530861198130203733c5c9ec4e5cca3a4037f5a8db4 \
+    --hash=sha256:feb699d4ab241ef5c1b80bb58277be2aaad365cd4b672d7817e0bc59ee45131b
     # via
     #   -c lock/requirements-dev.txt
     #   hexkit
-botocore==1.43.51 \
-    --hash=sha256:7c2c538c932bddc95834e177ce6f91dcc388c6a7934b4f8d0db13caa30e3e543 \
-    --hash=sha256:e0e5e88585fdb01dcb6b533ac2dd3f18d5d45092a14ccbfd330e3576a4152128
+botocore==1.43.56 \
+    --hash=sha256:6c01f85f0ff9863076f4c761e74ee3aa96c5ccc1ad09fc1efd62ef8f2d22bf57 \
+    --hash=sha256:aafc741f1b10f6fd63253eaf6ea029680c1ff436d87e1b8969d62aefa0c76976
     # via
     #   -c lock/requirements-dev.txt
     #   boto3
     #   hexkit
     #   s3transfer
-certifi==2026.6.17 \
-    --hash=sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432 \
-    --hash=sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db
+certifi==2026.7.22 \
+    --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775 \
+    --hash=sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55
     # via
     #   -c lock/requirements-dev.txt
-    #   httpcore
-    #   httpx
     #   requests
 cffi==2.1.0 \
     --hash=sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc \
@@ -439,9 +429,9 @@ email-validator==2.3.0 \
     # via
     #   -c lock/requirements-dev.txt
     #   pydantic
-fastapi==0.139.2 \
-    --hash=sha256:333145a6891e9b5b3cfceb69baf817e8240cde4d4588ae5a10bf56ffacb6255e \
-    --hash=sha256:b9ad015a835173d59865e2f5d8296fbc2b317bf56a2ba1a5bfbdd03de2fd4b1c
+fastapi==0.140.0 \
+    --hash=sha256:e951c0a0d9540bf5d9a2a9e078fd415da2ab7e312d435139e7d9e2e7fe9f0b23 \
+    --hash=sha256:f338951b82fd74ca8f843163aec43ea1a1ce84d515415a50fa98fa25572a5544
     # via
     #   -c lock/requirements-dev.txt
     #   ghga-service-commons (pyproject.toml)
@@ -450,26 +440,20 @@ h11==0.16.0 \
     --hash=sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
     # via
     #   -c lock/requirements-dev.txt
-    #   httpcore
+    #   httpcore2
     #   uvicorn
-hexkit==8.5.0 \
-    --hash=sha256:010effde769416dafc5782383772310f056370f9408b5435e66140109e93f6ab \
-    --hash=sha256:5d781a01e11d9737b076bc4a1d24b19f1ad45c879eae141fdc8258b8feea8e3c
+hexkit==8.6.0 \
+    --hash=sha256:fa27d6151e3a888ab401124a040bcb40ac3d0c69d63d14727f10795bf97947be \
+    --hash=sha256:faecfc22e3b9ccb9ad3015aae4345468c7c40d2a40f1b1af2a4b4e9c9b759ded
     # via
     #   -c lock/requirements-dev.txt
     #   ghga-service-commons (pyproject.toml)
-hishel==1.3.0 \
-    --hash=sha256:5be585dca8c035866cffc745a50dbce6b277a3d1f4b07ef24f77c07f6b31ff92 \
-    --hash=sha256:b803ad9f1d410085b61459a5dbbd273806215021e672198ba911c7d3db14adaa
+httpcore2==2.9.1 \
+    --hash=sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2 \
+    --hash=sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26
     # via
     #   -c lock/requirements-dev.txt
-    #   ghga-service-commons (pyproject.toml)
-httpcore==1.0.9 \
-    --hash=sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55 \
-    --hash=sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8
-    # via
-    #   -c lock/requirements-dev.txt
-    #   httpx
+    #   httpx2
 httptools==0.8.0 \
     --hash=sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683 \
     --hash=sha256:0ea897f0c729581ebf72131a438a7932d9b14efef72d75ada966700cac3caaeb \
@@ -524,9 +508,9 @@ httptools==0.8.0 \
     # via
     #   -c lock/requirements-dev.txt
     #   uvicorn
-httpx==0.28.1 \
-    --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
-    --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
+httpx2==2.9.1 \
+    --hash=sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a \
+    --hash=sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a
     # via
     #   -c lock/requirements-dev.txt
     #   ghga-service-commons (pyproject.toml)
@@ -537,7 +521,7 @@ idna==3.18 \
     #   -c lock/requirements-dev.txt
     #   anyio
     #   email-validator
-    #   httpx
+    #   httpx2
     #   requests
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
@@ -552,76 +536,6 @@ jwcrypto==1.5.8 \
     # via
     #   -c lock/requirements-dev.txt
     #   ghga-service-commons (pyproject.toml)
-msgpack==1.2.1 \
-    --hash=sha256:01e2dd6c9b19d333a00282330cc8a73d38d8dabc306dc5b42cd668c3ac82e833 \
-    --hash=sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a \
-    --hash=sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647 \
-    --hash=sha256:05f340e47e7e47d2da8db9b53e1bb1d294369e9ef45a747441309f6650b8351d \
-    --hash=sha256:0a70e3cf2804a300d921bb0940426e35f4e489a23adfb77a808892241db0a064 \
-    --hash=sha256:0adcf06ffde0777c0e1a9b771a2b1c4226ba1bbf748c8efcc02fcdeca3299107 \
-    --hash=sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac \
-    --hash=sha256:0e2bf9280bceb5efca998435904b5d3e9fdbcc11d90dc9df30aec7973252b720 \
-    --hash=sha256:1233ee2dd0cefba127583de50ea654677277047d238303521db35def3d7b2e7c \
-    --hash=sha256:146ee4e9ce80b365c6d4c47073da9da7bcec473e58194ceee5dd7620ace77e06 \
-    --hash=sha256:1548006a91aa93c5da81f3bdcebc1a0d10cea2d25969754fbe848da622b2b895 \
-    --hash=sha256:196300e7e5d6e74d50f1607ab9c06c4a1484c383cd22defd727902591f7e8dde \
-    --hash=sha256:1dabedcd0f23559f3596428c6589c1cd8c6eaed3a0d720795b07b0225d769203 \
-    --hash=sha256:20466cca18c49c7292a8984bc15d65857b171e7264bdcb5f96baf8be238791fc \
-    --hash=sha256:298872ecf9e61950f1c6af4ca969b859ee91783bb920ef6e6172697d0c8aad74 \
-    --hash=sha256:29a3f6e9667868429d8240dfd063ea5ffdc1321c13d783aa23827a38de0dcb22 \
-    --hash=sha256:2eda0b7ebb1283a98d3e4492ac933c8af6aff59fd3df1c3ed024f536af4b1dc8 \
-    --hash=sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35 \
-    --hash=sha256:2ff164c1b0bcb740b073b99e945234d0212852fa378e44a208c425379140dbeb \
-    --hash=sha256:33f14fba63278b714efe6ad07e50ea5f03d91537aa6a1c5f1ceca4cf44013ca9 \
-    --hash=sha256:350cb813d0af6e65d2f7ef0d729f7ff5be5a8bce03665892f43e5883d4ecc1b8 \
-    --hash=sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6 \
-    --hash=sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07 \
-    --hash=sha256:491cc39455ca765fad51fb451bf2915eb2cf41192ab5801ce8d67c1d614fe056 \
-    --hash=sha256:575957e79cd51903a4e8495a242442949641e08f1efd5197b43bebd3ea7682b4 \
-    --hash=sha256:5ad5467fc3f68b5468e06c5f788d712e9f8ffc8b0cd1bcb160c105c1ee92dae7 \
-    --hash=sha256:5bb9c386f0a329c035ddbab4b72d1028bf9627add8dda41070288563d57ed1b1 \
-    --hash=sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24 \
-    --hash=sha256:5f6277e5f783c36786a145e0247fc189a03f35f84b251646e53592d2bc12b355 \
-    --hash=sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0 \
-    --hash=sha256:633727297ed063441fd1cda2288865487f33ad14eeb8831afb5f0c396a62cfce \
-    --hash=sha256:67f6dd22fa72a93752643f07889796d62739a13415ee630169a8ce764f86cf9f \
-    --hash=sha256:6d09badf350af2be9d189184e04e64cf54ad93569ab3d96fca58bd3e84aad707 \
-    --hash=sha256:6ee967f7c7e1df2890c671ff2ee51a28ded0efc95da3e507176dee881ce36c66 \
-    --hash=sha256:74847557e28ce71bd3c438a447ca90e4b507e997ddbdef8a12a7b283b86c156b \
-    --hash=sha256:779197a6513bab3c3632265e3d0f7cb3227e62510841a6f34f1eaa37efbb345e \
-    --hash=sha256:787c9bebb5833e8f6fc8abca3c0597683d8d87f56a8842b6b89c75a5f3176e2d \
-    --hash=sha256:7d31c0ac0c640f877804c67cb2bc9f4e23dc2db97e96c2e67fa27d38283b41f8 \
-    --hash=sha256:810b916696c86ef0deb3b74588480224df4c1b071136c34183e4a2a4284d7ac7 \
-    --hash=sha256:83efa1c898e0fc5380fc0cabbf75164c52e3b5cbb45973710d75821928380c73 \
-    --hash=sha256:85f57e960d877f2977f6430896191b04a21f8901b3b4baf2e4604329f4db5402 \
-    --hash=sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a \
-    --hash=sha256:8c2ed1e48cc0f460bf3c7780e7137ff21a4e18433451916f2442c1b21036cd7d \
-    --hash=sha256:8c7b398c56ff125feae96c2737abfec5595f1fa0aa186df60c56040b8accb95c \
-    --hash=sha256:8d00f177ca88a77c1cf848d204a38f249751650b601cb6532acc68805d8a8273 \
-    --hash=sha256:8ff92d7feeaf5bc26c51495b69e2f99ed97ab79346fb6555f44be7dd2ac6503b \
-    --hash=sha256:91054a783328e0ea7954b8771095705c8d2243b814743fbaadf14552c9c52c5d \
-    --hash=sha256:98b58bdb89c46190e4609bb36abe17c6d4105ad13f9c5f8f6f64d320f8ced3fb \
-    --hash=sha256:a28d076ca7c82b9c8728ad90b7147489449557038bed50e4241eb832395169b4 \
-    --hash=sha256:aa6c4be5d1c02a42b066ca6ddb71adf36432868fdcdb6ee87e634e86e0674190 \
-    --hash=sha256:aded5bdf32609dc7987a49bbbd15a8ef096193f96dd8bbeb791de729e650acf5 \
-    --hash=sha256:afc5febcd4c99effbc02b528e49d6fd0760b2b7d48c05239e345a5fa6e743d9a \
-    --hash=sha256:b50b727bd652bdc37d950336c848ef20ec54a4cafc38dce19b1cd86ad625d0f7 \
-    --hash=sha256:c1c79a604a2969a868a78b6ebd27a887e00c624f14f66b3038e0590cb23332d1 \
-    --hash=sha256:ca0dacff965c47afdc3749a8469d7302a8f801d6a28758d55120d75e66ce6889 \
-    --hash=sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c \
-    --hash=sha256:dc871b997a9370d855b7394465f2f350e847a5b806dd38dcc9c989e7d87da155 \
-    --hash=sha256:dd3bfe82d53edfe4b7fc9a7ec9761e23a7a5b1dac22264505af428253c29ed24 \
-    --hash=sha256:e3dc2feb0876209d9c38aa56cb1de169bd6c4348f1aa48271f241226590993e6 \
-    --hash=sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1 \
-    --hash=sha256:ec0e675d59150a6269ddc9139087c722292664a37d071a849c05c473350f1f2d \
-    --hash=sha256:ee1d9ed27d0497b848923746cf762ed2e7db24f4be7eec8e5cbe8c766aa707b7 \
-    --hash=sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64 \
-    --hash=sha256:f12038a35fabd52e56a3547bab42401af49a45caa6dd00b34c44de235bc93ee2 \
-    --hash=sha256:f310233ef7fb9c14e201c93639fe5f5260b005f56f0b29048e999c30935596cc \
-    --hash=sha256:f9389552ecf4784886345ead0647e4edc96bee37cbab05b75540f542f766c48c
-    # via
-    #   -c lock/requirements-dev.txt
-    #   hishel
 opentelemetry-api==1.44.0 \
     --hash=sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a \
     --hash=sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef
@@ -899,9 +813,9 @@ requests==2.34.2 \
     # via
     #   -c lock/requirements-dev.txt
     #   ghga-service-commons (pyproject.toml)
-s3transfer==0.19.1 \
-    --hash=sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3 \
-    --hash=sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de
+s3transfer==0.19.2 \
+    --hash=sha256:ba0309fd86be3c27dbf78cdd813c13c5e1df16e5874b99d2535ebbdfb9892993 \
+    --hash=sha256:d8168eccca828cbb2cd573675333f3bddd254313a9c42494b84c76b539e8ba25
     # via
     #   -c lock/requirements-dev.txt
     #   boto3
@@ -923,13 +837,19 @@ tenacity==9.1.4 \
     # via
     #   -c lock/requirements-dev.txt
     #   ghga-service-commons (pyproject.toml)
+truststore==0.10.4 \
+    --hash=sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301 \
+    --hash=sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981
+    # via
+    #   -c lock/requirements-dev.txt
+    #   httpcore2
+    #   httpx2
 typing-extensions==4.16.0 \
     --hash=sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8 \
     --hash=sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5
     # via
     #   -c lock/requirements-dev.txt
     #   fastapi
-    #   hishel
     #   jwcrypto
     #   opentelemetry-api
     #   pydantic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "Intended Audience :: Developers",
 ]
 name = "ghga_service_commons"
-version = "7.1.0"
+version = "8.0.0"
 description = "A library that contains common functionality used in services of GHGA"
 dependencies = [
     "pydantic >=2, <3",
@@ -40,7 +40,7 @@ api = [
     "ghga-service-commons[http,objectstorage]",
 ]
 http = [
-    "httpx>=0.28, <0.29",
+    "httpx2>=2.9.1, <3",
 ]
 auth = [
     "jwcrypto>=1.5.6, <2",
@@ -57,7 +57,6 @@ objectstorage = [
     "hexkit[s3]>=8",
 ]
 transports = [
-    "hishel[async]>=1.1.8, <2",
     "tenacity >=9.1.2, <10",
     "ghga-service-commons[http]",
 ]

--- a/src/ghga_service_commons/api/mock_router.py
+++ b/src/ghga_service_commons/api/mock_router.py
@@ -402,5 +402,20 @@ class MockRouter(Generic[ExpectedExceptionTypes]):
             raise
 
     def as_transport(self) -> httpx2.MockTransport:
-        """Return a transport routing through this router, for Client or AsyncClient."""
+        """Return a transport routing through this router, for Client or AsyncClient.
+
+        For simple use cases this can be mounted directly on the client:
+        ```
+        httpx2.Client(base_url=BASE_URL, transport=router.as_transport())
+        ```
+
+        For more complex use cases, provide it as the innermost layer of a custom
+        transport stack, so the requests are still routed here after passing through
+        the wrapping transports:
+        ```
+        CompositeTransportFactory.create_ratelimiting_retry_transport(
+            config, base_transport=router.as_transport()
+        )
+        ```
+        """
         return httpx2.MockTransport(self.handle_request)

--- a/src/ghga_service_commons/api/mock_router.py
+++ b/src/ghga_service_commons/api/mock_router.py
@@ -13,7 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""A class for mocking API endpoints when testing with the httpx_mock fixture."""
+"""A class for mocking API endpoints, for use with ``httpx2.MockTransport``.
+
+:class:`MockRouter` does the routing itself -- endpoints are registered with
+FastAPI-style decorators and matched against the request path and method -- so no
+third-party mocking plugin is required. Mount it on a client via the transport that
+HTTPX2 ships for exactly this purpose::
+
+    app = MockRouter()
+
+    @app.get("/items/{item_id}")
+    def get_item(item_id: int) -> httpx2.Response:
+        return httpx2.Response(status_code=200, json={"id": item_id})
+
+    with httpx2.Client(transport=app.as_transport()) as client:
+        response = client.get("/items/42")
+
+The same transport works with ``httpx2.AsyncClient``. Everything here is typed
+against HTTPX2; registered endpoints take ``httpx2.Request`` and return
+``httpx2.Response``.
+"""
 
 from __future__ import annotations
 
@@ -23,8 +42,7 @@ from functools import partial
 from inspect import signature
 from typing import Any, Generic, TypeVar, cast, get_type_hints
 
-import httpx
-import pytest
+import httpx2
 from pydantic import BaseModel
 
 from ghga_service_commons.httpyexpect.server.exceptions import HttpException
@@ -32,7 +50,6 @@ from ghga_service_commons.httpyexpect.server.exceptions import HttpException
 __all__ = [
     "HttpException",
     "MockRouter",
-    "assert_all_responses_were_requested",
 ]
 
 BRACKET_PATTERN = re.compile(r"{.*?}")
@@ -68,16 +85,6 @@ def _get_signature_info(endpoint_function: Callable) -> dict[str, Any]:
     return signature_parameters
 
 
-@pytest.fixture
-def assert_all_responses_were_requested() -> bool:
-    """Whether httpx checks that all registered responses are sent back.
-    This is set to false because the registered endpoints are considered mocked even if
-    they aren't used in a given test. If this is True (default), pytest_httpx will raise
-    an error if a given test doesn't hit every mocked endpoint.
-    """
-    return False
-
-
 class RegisteredEndpoint(BaseModel):
     """Endpoint data with the url turned into regex string to get parameters in path."""
 
@@ -106,7 +113,7 @@ class MockRouter(Generic[ExpectedExceptionTypes]):
 
     def __init__(
         self,
-        exception_handler: Callable[[httpx.Request, ExpectedExceptionTypes], Any]
+        exception_handler: Callable[[httpx2.Request, ExpectedExceptionTypes], Any]
         | None = None,
         exceptions_to_handle: tuple[type[Exception], ...] | None = None,
         handle_exception_subclasses: bool = False,
@@ -116,7 +123,7 @@ class MockRouter(Generic[ExpectedExceptionTypes]):
         Args:
             `exception_handler`:
                 custom exception handler function that takes the request and exception
-                as arguments, in that order. It must take an httpx.Request object as
+                as arguments, in that order. It must take an httpx2.Request object as
                 the first argument and any subclass of Exception as the second argument.
                 This allows your exception handler signature to be more specifically typed.
 
@@ -263,7 +270,7 @@ class MockRouter(Generic[ExpectedExceptionTypes]):
     def _convert_parameter_types(
         parsed_url_parameters: dict[str, str],
         signature_parameters: dict[str, Any],
-        request: httpx.Request,
+        request: httpx2.Request,
     ) -> dict[str, Any]:
         """Get type info for function parameters.
 
@@ -357,7 +364,7 @@ class MockRouter(Generic[ExpectedExceptionTypes]):
             data={"url": url, "method": method},
         )
 
-    def _build_loaded_endpoint_function(self, request: httpx.Request) -> partial:
+    def _build_loaded_endpoint_function(self, request: httpx2.Request) -> partial:
         """Match a request to the correct endpoint.
 
         Based on the endpoint matched, build the typed parameter dictionary and
@@ -395,17 +402,18 @@ class MockRouter(Generic[ExpectedExceptionTypes]):
                 pass_to_handler = True
         return pass_to_handler
 
-    def handle_request(self, request: httpx.Request):
+    def handle_request(self, request: httpx2.Request) -> httpx2.Response:
         """Route intercepted request to the registered endpoint and return response.
 
-        If using this with httpx_mock, then this function should be the callback.
-        e.g.:
-        ```
-        httpx_mock.add_callback(callback=mock_router.handle_request)
-        ```
+        This is the handler to hand to ``httpx2.MockTransport``::
+
+            transport = httpx2.MockTransport(mock_router.handle_request)
+            with httpx2.Client(transport=transport) as client: ...
+
         If self.exception_handler is specified, any errors matching self.exceptions_to_handle
         will be passed to the handler. In all other cases, the exception will be
-        re-raised.
+        re-raised. ``MockTransport`` calls this handler directly, so exceptions
+        surface unchanged at the call site.
         """
         try:
             endpoint_function = self._build_loaded_endpoint_function(request)
@@ -417,3 +425,14 @@ class MockRouter(Generic[ExpectedExceptionTypes]):
                 )  # satisfy type-checker by making exc type 'E'
                 return self.exception_handler(request, exc)
             raise
+
+    def as_transport(self) -> httpx2.MockTransport:
+        """Return an ``httpx2.MockTransport`` that routes through this router.
+
+        Convenience wrapper so tests can mount the router on a client directly::
+
+            with httpx2.Client(transport=mock_router.as_transport()) as client: ...
+
+        The same transport also works with ``httpx2.AsyncClient``.
+        """
+        return httpx2.MockTransport(self.handle_request)

--- a/src/ghga_service_commons/api/mock_router.py
+++ b/src/ghga_service_commons/api/mock_router.py
@@ -13,26 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""A class for mocking API endpoints, for use with ``httpx2.MockTransport``.
-
-:class:`MockRouter` does the routing itself -- endpoints are registered with
-FastAPI-style decorators and matched against the request path and method -- so no
-third-party mocking plugin is required. Mount it on a client via the transport that
-HTTPX2 ships for exactly this purpose::
-
-    app = MockRouter()
-
-    @app.get("/items/{item_id}")
-    def get_item(item_id: int) -> httpx2.Response:
-        return httpx2.Response(status_code=200, json={"id": item_id})
-
-    with httpx2.Client(transport=app.as_transport()) as client:
-        response = client.get("/items/42")
-
-The same transport works with ``httpx2.AsyncClient``. Everything here is typed
-against HTTPX2; registered endpoints take ``httpx2.Request`` and return
-``httpx2.Response``.
-"""
+"""A class for mocking API endpoints, mounted via ``MockRouter.as_transport()``."""
 
 from __future__ import annotations
 
@@ -405,15 +386,9 @@ class MockRouter(Generic[ExpectedExceptionTypes]):
     def handle_request(self, request: httpx2.Request) -> httpx2.Response:
         """Route intercepted request to the registered endpoint and return response.
 
-        This is the handler to hand to ``httpx2.MockTransport``::
-
-            transport = httpx2.MockTransport(mock_router.handle_request)
-            with httpx2.Client(transport=transport) as client: ...
-
         If self.exception_handler is specified, any errors matching self.exceptions_to_handle
         will be passed to the handler. In all other cases, the exception will be
-        re-raised. ``MockTransport`` calls this handler directly, so exceptions
-        surface unchanged at the call site.
+        re-raised.
         """
         try:
             endpoint_function = self._build_loaded_endpoint_function(request)
@@ -427,12 +402,5 @@ class MockRouter(Generic[ExpectedExceptionTypes]):
             raise
 
     def as_transport(self) -> httpx2.MockTransport:
-        """Return an ``httpx2.MockTransport`` that routes through this router.
-
-        Convenience wrapper so tests can mount the router on a client directly::
-
-            with httpx2.Client(transport=mock_router.as_transport()) as client: ...
-
-        The same transport also works with ``httpx2.AsyncClient``.
-        """
+        """Return a transport routing through this router, for Client or AsyncClient."""
         return httpx2.MockTransport(self.handle_request)

--- a/src/ghga_service_commons/api/testing.py
+++ b/src/ghga_service_commons/api/testing.py
@@ -20,7 +20,7 @@ import socket
 from collections.abc import Callable
 from typing import Any, Generic, TypeVar
 
-import httpx
+import httpx2
 
 __all__ = ["AsyncTestClient", "get_free_port"]
 
@@ -35,7 +35,7 @@ def get_free_port() -> int:
 TApp = TypeVar("TApp", bound=Callable[..., Any])
 
 
-class AsyncTestClient(httpx.AsyncClient, Generic[TApp]):
+class AsyncTestClient(httpx2.AsyncClient, Generic[TApp]):
     """Client for testing ASGI apps in the context of a running async event loop.
 
     Usage: ```
@@ -64,5 +64,5 @@ class AsyncTestClient(httpx.AsyncClient, Generic[TApp]):
         """Initialize with ASGI app."""
         self.app = app  # make the application available to tests as well
         super().__init__(
-            transport=httpx.ASGITransport(app=app), base_url="http://localhost:8080"
+            transport=httpx2.ASGITransport(app=app), base_url="http://localhost:8080"
         )

--- a/src/ghga_service_commons/http/correlation.py
+++ b/src/ghga_service_commons/http/correlation.py
@@ -16,7 +16,7 @@
 
 from functools import partial
 
-import httpx
+import httpx2
 from hexkit.correlation import (
     CorrelationIdContextError,
     get_correlation_id,
@@ -49,11 +49,11 @@ async def _cid_request_hook(request, generate_correlation_id: bool):
 
 
 def attach_correlation_id_to_requests(
-    client: httpx.AsyncClient,
+    client: httpx2.AsyncClient,
     *,
     generate_correlation_id: bool = True,
 ):
-    """Add an event hook to an httpx Client that includes the correlation ID header."""
+    """Add an event hook to an httpx2 Client that includes the correlation ID header."""
     event_hook = partial(
         _cid_request_hook,
         generate_correlation_id=generate_correlation_id,
@@ -61,8 +61,8 @@ def attach_correlation_id_to_requests(
     client.event_hooks.setdefault("request", []).append(event_hook)
 
 
-class AsyncClient(httpx.AsyncClient):
-    """A version of httpx.AsyncClient that attaches the correlation ID header in requests.
+class AsyncClient(httpx2.AsyncClient):
+    """A version of httpx2.AsyncClient that attaches the correlation ID header in requests.
 
     If no correlation ID is found in the current context, a new one will be generated
     OR an error will be raised based on the value of `generate_correlation_id`.

--- a/src/ghga_service_commons/httpyexpect/client/custom_types.py
+++ b/src/ghga_service_commons/httpyexpect/client/custom_types.py
@@ -35,7 +35,7 @@ ExceptionMappingSpec = Mapping[StatusCode, object]
 
 
 class Response(Protocol):
-    """Any Response that is compatible with httpx and requests."""
+    """Any Response that is compatible with httpx2 and requests."""
 
     status_code: int
     """Status code of the Response"""

--- a/src/ghga_service_commons/httpyexpect/client/translator.py
+++ b/src/ghga_service_commons/httpyexpect/client/translator.py
@@ -43,7 +43,7 @@ class ResponseTranslator:
 
         Args:
             response:
-                A response to an HTTP call performed e.g. with the `httpx` or `requests`
+                A response to an HTTP call performed e.g. with the `httpx2` or `requests`
                 library.
             exception_map:
                 An exception mapping specifying translations between status codes plus

--- a/src/ghga_service_commons/transports/__init__.py
+++ b/src/ghga_service_commons/transports/__init__.py
@@ -15,26 +15,18 @@
 
 """Pluggable, custom and composable logic around HTTP calls."""
 
-from hishel.httpx import AsyncCacheTransport
-
-from .config import CompositeCacheConfig, CompositeConfig
+from .config import CompositeConfig
 from .factory import (
     AsyncRateLimitingTransport,
     AsyncRetryTransport,
     CompositeTransportFactory,
 )
-from .proxy_handling import (
-    cached_ratelimiting_retry_proxies,
-    ratelimiting_retry_proxies,
-)
+from .proxy_handling import ratelimiting_retry_proxies
 
 __all__ = [
-    "AsyncCacheTransport",
     "AsyncRateLimitingTransport",
     "AsyncRetryTransport",
-    "CompositeCacheConfig",
     "CompositeConfig",
     "CompositeTransportFactory",
-    "cached_ratelimiting_retry_proxies",
     "ratelimiting_retry_proxies",
 ]

--- a/src/ghga_service_commons/transports/config.py
+++ b/src/ghga_service_commons/transports/config.py
@@ -13,30 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Contains common configuration for different composite async httpx Transports."""
+"""Contains common configuration for different composite async httpx2 Transports."""
 
 from pydantic import Field, NonNegativeFloat, NonNegativeInt, PositiveInt
 from pydantic_settings import BaseSettings
-
-
-class CacheTransportConfig(BaseSettings):
-    """Configuration options for the storage used in the caching transport.
-
-    Currently only in memory storage is available.
-    """
-
-    client_cache_capacity: PositiveInt = Field(
-        default=128,
-        description="Maximum number of entries to store in the cache. Older entries are evicted once this limit is reached.",
-    )
-    client_cache_ttl: NonNegativeInt = Field(
-        default=60,
-        description="Number of seconds after which a stored response is considered stale.",
-    )
-    client_cacheable_methods: list[str] = Field(
-        default=["POST", "GET"],
-        description="HTTP methods for which responses are allowed to be cached.",
-    )
 
 
 class RateLimitingTransportConfig(BaseSettings):
@@ -77,7 +57,3 @@ class RetryTransportConfig(BaseSettings):
 
 class CompositeConfig(RateLimitingTransportConfig, RetryTransportConfig):
     """Configuration for a transport providing both retry and rate limiting logic."""
-
-
-class CompositeCacheConfig(CompositeConfig, CacheTransportConfig):
-    """Configuration for a transport providing retry, rate limiting and caching logic."""

--- a/src/ghga_service_commons/transports/factory.py
+++ b/src/ghga_service_commons/transports/factory.py
@@ -13,16 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Provides factories for different flavors of httpx.AsyncHTTPTransport."""
+"""Provides factories for different flavors of httpx2.AsyncHTTPTransport."""
 
 import os
 import ssl
 
-from hishel import AsyncSqliteStorage, FilterPolicy
-from hishel.httpx import AsyncCacheTransport
-from httpx import AsyncBaseTransport, AsyncHTTPTransport, Limits
+from httpx2 import AsyncBaseTransport, AsyncHTTPTransport, Limits
 
-from .config import CompositeCacheConfig, CompositeConfig
+from .config import CompositeConfig
 from .ratelimiting import AsyncRateLimitingTransport
 from .retry import AsyncRetryTransport
 
@@ -36,8 +34,12 @@ def get_ssl_verify() -> ssl.SSLContext | bool:
     chains verify correctly. ``REQUESTS_CA_BUNDLE`` takes precedence.
 
     If either variable is set, an ``ssl.SSLContext`` loaded from the referenced CA
-    bundle is returned. If neither is set, ``True`` is returned so that httpx keeps
-    its default behavior (certifi's bundled root certificates).
+    bundle is returned. If neither is set, ``True`` is returned so that httpx2 keeps
+    its default behavior, which is to verify against the operating system's trust
+    store via ``truststore``. Note that this differs from httpx 0.x, which verified
+    against certifi's bundled root certificates: deployments on minimal container
+    images must ensure the system CA store is populated (e.g. ``ca-certificates``),
+    or set ``REQUESTS_CA_BUNDLE``/``SSL_CERT_FILE`` explicitly.
     """
     ca_bundle = os.environ.get("REQUESTS_CA_BUNDLE") or os.environ.get("SSL_CERT_FILE")
     if ca_bundle:
@@ -46,7 +48,7 @@ def get_ssl_verify() -> ssl.SSLContext | bool:
 
 
 class CompositeTransportFactory:
-    """Produces different flavors of httpx.AsyncHTTPTransports and takes care of wrapping them in the correct order."""
+    """Produces different flavors of httpx2.AsyncHTTPTransports and takes care of wrapping them in the correct order."""
 
     @classmethod
     def _create_common_transport_layers(
@@ -87,28 +89,4 @@ class CompositeTransportFactory:
         """
         return cls._create_common_transport_layers(
             config, base_transport=base_transport, limits=limits
-        )
-
-    @classmethod
-    def create_cached_ratelimiting_retry_transport(
-        cls,
-        config: CompositeCacheConfig,
-        base_transport: AsyncBaseTransport | None = None,
-        limits: Limits | None = None,
-    ) -> AsyncCacheTransport:
-        """Creates a cache transport, wrapping, in sequence, a retry, rate limiting transport and AsyncHTTPTransport.
-
-        If provided, limits are applied to the wrapped AsyncHTTPTransport instance.
-        If provided, a custom base_transport class is used and any limits are ignored.
-        Those have to be provided directly to the custom base_transport passed into this method.
-        """
-        retry_transport = cls._create_common_transport_layers(
-            config, base_transport=base_transport, limits=limits
-        )
-        policy = FilterPolicy()
-        storage = AsyncSqliteStorage(default_ttl=config.client_cache_ttl)
-        return AsyncCacheTransport(
-            next_transport=retry_transport,
-            storage=storage,
-            policy=policy,
         )

--- a/src/ghga_service_commons/transports/factory.py
+++ b/src/ghga_service_commons/transports/factory.py
@@ -35,11 +35,8 @@ def get_ssl_verify() -> ssl.SSLContext | bool:
 
     If either variable is set, an ``ssl.SSLContext`` loaded from the referenced CA
     bundle is returned. If neither is set, ``True`` is returned so that httpx2 keeps
-    its default behavior, which is to verify against the operating system's trust
-    store via ``truststore``. Note that this differs from httpx 0.x, which verified
-    against certifi's bundled root certificates: deployments on minimal container
-    images must ensure the system CA store is populated (e.g. ``ca-certificates``),
-    or set ``REQUESTS_CA_BUNDLE``/``SSL_CERT_FILE`` explicitly.
+    its default behavior: the OS trust store via ``truststore``, not certifi as in
+    httpx 0.x. Minimal images therefore need a populated system CA store.
     """
     ca_bundle = os.environ.get("REQUESTS_CA_BUNDLE") or os.environ.get("SSL_CERT_FILE")
     if ca_bundle:

--- a/src/ghga_service_commons/transports/proxy_handling.py
+++ b/src/ghga_service_commons/transports/proxy_handling.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This module provides custom proxy handling, as the way httpx setups the client, there is
+This module provides custom proxy handling, as the way httpx2 setups the client, there is
 an order of precedence which necessitates manual setup for proxies if a custom transport
 is provided.
 
@@ -22,39 +22,17 @@ client and will parse env proxies unconditionally.
 If you don't want to trust the env, don't use the functions from this module.
 
 NO_PROXY is now respected: hosts excluded from proxying via NO_PROXY are kept as
-`None` mounts, which tells httpx to connect directly for them. Note that wildcard and
-CIDR NO_PROXY entries behave according to httpx's mount pattern matching rather than
-httpx's own NO_PROXY logic (which is bypassed entirely once `mounts` are supplied).
+`None` mounts, which tells httpx2 to connect directly for them. Note that wildcard and
+CIDR NO_PROXY entries behave according to httpx2's mount pattern matching rather than
+httpx2's own NO_PROXY logic (which is bypassed entirely once `mounts` are supplied).
 This is a pre-existing limitation of routing through `mounts` and is not introduced
 by this handling.
 """
 
-from httpx import AsyncBaseTransport, AsyncHTTPTransport, Limits, _utils
+from httpx2 import AsyncBaseTransport, AsyncHTTPTransport, Limits, _utils
 
-from .config import CompositeCacheConfig, CompositeConfig
+from .config import CompositeConfig
 from .factory import CompositeTransportFactory, get_ssl_verify
-
-
-def cached_ratelimiting_retry_proxies(
-    config: CompositeCacheConfig,
-    limits: Limits | None = None,
-):
-    """Setup proxies from env for cached ratelimiting retry transport.
-
-    The returned dictionary needs to be provided as `mounts` to the client.
-    """
-    mounts: dict[str, AsyncBaseTransport | None] = {}
-    for key, transport in _get_base_proxies_from_env().items():
-        if transport is None:
-            # NO_PROXY host: keep None so httpx connects directly for this host.
-            mounts[key] = None
-            continue
-        mounts[key] = (
-            CompositeTransportFactory.create_cached_ratelimiting_retry_transport(
-                config=config, base_transport=transport, limits=limits
-            )
-        )
-    return mounts
 
 
 def ratelimiting_retry_proxies(
@@ -68,7 +46,7 @@ def ratelimiting_retry_proxies(
     mounts: dict[str, AsyncBaseTransport | None] = {}
     for key, transport in _get_base_proxies_from_env().items():
         if transport is None:
-            # NO_PROXY host: keep None so httpx connects directly for this host.
+            # NO_PROXY host: keep None so httpx2 connects directly for this host.
             mounts[key] = None
             continue
         mounts[key] = CompositeTransportFactory.create_ratelimiting_retry_transport(
@@ -78,13 +56,13 @@ def ratelimiting_retry_proxies(
 
 
 def _get_base_proxies_from_env() -> dict[str, AsyncHTTPTransport | None]:
-    """Use httpx internals to correctly parse proxy environment variables.
+    """Use httpx2 internals to correctly parse proxy environment variables.
 
     This will populate http, https and all proxy settings and create transports
     based on those proxy strings.
 
-    NO_PROXY hosts are returned by httpx with a ``None`` url; these are preserved as
-    ``None`` so that NO_PROXY is respected (httpx connects directly for them) instead
+    NO_PROXY hosts are returned by httpx2 with a ``None`` url; these are preserved as
+    ``None`` so that NO_PROXY is respected (httpx2 connects directly for them) instead
     of being silently routed through a proxy.
     """
     verify = get_ssl_verify()

--- a/src/ghga_service_commons/transports/ratelimiting.py
+++ b/src/ghga_service_commons/transports/ratelimiting.py
@@ -72,6 +72,8 @@ class AsyncRateLimitingTransport(httpx2.AsyncBaseTransport):
             await asyncio.sleep(sleep_for)
 
         # Delegate call and update timestamp
+        # Strictly pass request as non kwarg arg to work around Otel httpx
+        # instrumentation trying to extract from arg[0]
         response = await self._transport.handle_async_request(request)
 
         # Update state

--- a/src/ghga_service_commons/transports/ratelimiting.py
+++ b/src/ghga_service_commons/transports/ratelimiting.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Provides an httpx.AsyncTransport that handles rate limiting responses."""
+"""Provides an httpx2.AsyncTransport that handles rate limiting responses."""
 
 import asyncio
 import random
@@ -21,14 +21,14 @@ import time
 from logging import getLogger
 from types import TracebackType
 
-import httpx
+import httpx2
 
 from ghga_service_commons.transports.config import RateLimitingTransportConfig
 
 log = getLogger(__name__)
 
 
-class AsyncRateLimitingTransport(httpx.AsyncBaseTransport):
+class AsyncRateLimitingTransport(httpx2.AsyncBaseTransport):
     """Custom async Transport adding rate limiting handling on top of AsyncHTTPTransport.
 
     If no retry-after header is found in the 429 response, this hands control back to the
@@ -41,7 +41,7 @@ class AsyncRateLimitingTransport(httpx.AsyncBaseTransport):
     """
 
     def __init__(
-        self, config: RateLimitingTransportConfig, transport: httpx.AsyncBaseTransport
+        self, config: RateLimitingTransportConfig, transport: httpx2.AsyncBaseTransport
     ) -> None:
         self._jitter = config.per_request_jitter
         self._transport = transport
@@ -50,7 +50,7 @@ class AsyncRateLimitingTransport(httpx.AsyncBaseTransport):
         self._last_retry_after_received: float = 0
         self._wait_time: float = 0
 
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
         """Handles HTTP requests and adds wait logic for HTTP 429 responses around calls."""
         # Calculate seconds since the last request has been fired and corresponding wait time
         time_elapsed = time.monotonic() - self._last_retry_after_received

--- a/src/ghga_service_commons/transports/retry.py
+++ b/src/ghga_service_commons/transports/retry.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Provides an httpx.AsyncTransport that handles retrying requests on failure."""
+"""Provides an httpx2.AsyncTransport that handles retrying requests on failure."""
 
 import time
 from collections.abc import Callable
@@ -21,7 +21,7 @@ from logging import getLogger
 from types import TracebackType
 from typing import Any
 
-import httpx
+import httpx2
 from tenacity import (
     AsyncRetrying,
     RetryCallState,
@@ -71,7 +71,7 @@ def _log_retry_stats(retry_state: RetryCallState):
             exc = outcome.exception()
             stats["exception_type"] = type(exc)
             stats["exception_message"] = str(exc)
-        elif isinstance(result := outcome.result(), httpx.Response):
+        elif isinstance(result := outcome.result(), httpx2.Response):
             stats["response_status_code"] = result.status_code
             stats["response_headers"] = result.headers
 
@@ -118,7 +118,7 @@ class wait_exponential_ignore_429(wait_exponential):  # noqa: N801
         if outcome is not None and not outcome.failed:
             result = outcome.result()
             if (
-                isinstance(result, httpx.Response)
+                isinstance(result, httpx2.Response)
                 and result.status_code == 429
                 and not result.headers.get("Should-Wait")
             ):
@@ -131,7 +131,7 @@ class wait_exponential_ignore_429(wait_exponential):  # noqa: N801
         return max(max(0, self.min), min(result, self.max))
 
 
-class AsyncRetryTransport(httpx.AsyncBaseTransport):
+class AsyncRetryTransport(httpx2.AsyncBaseTransport):
     """Custom async Transport adding retry logic on top of AsyncHTTPTransport.
 
     This adds tenacity based retry logic around HTTP calls.
@@ -140,10 +140,10 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
     so their retry-after header can be dealt with correctly, if present.
     """
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         config: RetryTransportConfig,
-        transport: httpx.AsyncBaseTransport,
+        transport: httpx2.AsyncBaseTransport,
         wait_strategy: Callable[[RetryTransportConfig], Any] = _default_wait_strategy,
         stop_strategy: Callable[[RetryTransportConfig], Any] = _default_stop_strategy,
         stats_logger: Callable[[RetryCallState], Any] = _log_retry_stats,
@@ -158,13 +158,13 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
             before_logger=before_logger,
         )
 
-    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
         """Handles HTTP requests and adds retry logic around calls."""
         # Track the latest response and close it before issuing the next attempt, leaving
         # only the final response open to consume by the caller.
-        latest_response: httpx.Response | None = None
+        latest_response: httpx2.Response | None = None
 
-        async def _attempt() -> httpx.Response:
+        async def _attempt() -> httpx2.Response:
             nonlocal latest_response
             if latest_response is not None:
                 # Always clear the reference so a later cleanup doesn't try to close the same response again.
@@ -172,7 +172,7 @@ class AsyncRetryTransport(httpx.AsyncBaseTransport):
                     await latest_response.aclose()
                 finally:
                     latest_response = None
-            # Strictly pass request as non kwarg arg to work around Otel httpx
+            # Strictly pass request as non kwarg arg to work around Otel httpx2
             # instrumentation trying to extract from arg[0]
             latest_response = await self._transport.handle_async_request(request)
             return latest_response
@@ -219,10 +219,10 @@ def _configure_retry_handler(
         retry=(
             retry_if_exception_type(
                 (
-                    httpx.TimeoutException,
-                    httpx.NetworkError,
-                    httpx.RemoteProtocolError,
-                    httpx.ProxyError,
+                    httpx2.TimeoutException,
+                    httpx2.NetworkError,
+                    httpx2.RemoteProtocolError,
+                    httpx2.ProxyError,
                 )
             )
             | retry_if_result(

--- a/src/ghga_service_commons/transports/retry.py
+++ b/src/ghga_service_commons/transports/retry.py
@@ -172,7 +172,7 @@ class AsyncRetryTransport(httpx2.AsyncBaseTransport):
                     await latest_response.aclose()
                 finally:
                     latest_response = None
-            # Strictly pass request as non kwarg arg to work around Otel httpx2
+            # Strictly pass request as non kwarg arg to work around Otel httpx
             # instrumentation trying to extract from arg[0]
             latest_response = await self._transport.handle_async_request(request)
             return latest_response

--- a/tests/integration/fixtures/mock_api.py
+++ b/tests/integration/fixtures/mock_api.py
@@ -17,7 +17,7 @@
 
 import json
 
-import httpx
+import httpx2
 
 from ghga_service_commons.api.mock_router import MockRouter
 from ghga_service_commons.httpyexpect.server.exceptions import HttpException
@@ -28,13 +28,13 @@ app: MockRouter = MockRouter(exceptions_to_handle=(HttpException,))
 
 # basic way to register an endpoint
 @app.get("/hello")
-def basic() -> httpx.Response:
+def basic() -> httpx2.Response:
     """Define a basic endpoint."""
-    return httpx.Response(status_code=200, json={"hello": "world"})
+    return httpx2.Response(status_code=200, json={"hello": "world"})
 
 
 @app.get("/items")
-def get_all_items(request: httpx.Request) -> httpx.Response:
+def get_all_items(request: httpx2.Request) -> httpx2.Response:
     """Endpoint meant to match path with the POST endpoint defined below."""
     if request.method == "POST":
         raise HttpException(
@@ -43,17 +43,17 @@ def get_all_items(request: httpx.Request) -> httpx.Response:
             description="A POST request was routed to a GET endpoint",
             data={},
         )
-    return httpx.Response(status_code=200, json={"hello": "world"})
+    return httpx2.Response(status_code=200, json={"hello": "world"})
 
 
 @app.get("/items/{item_name}")
-def get_item(item_name: str) -> httpx.Response:
+def get_item(item_name: str) -> httpx2.Response:
     """Endpoint with only one path variable."""
-    return httpx.Response(status_code=200, json={"expected": item_name})
+    return httpx2.Response(status_code=200, json={"expected": item_name})
 
 
 @app.get("/items/{item_name}/sizes/{item_size}")
-def get_item_and_size(item_name: str, item_size: int) -> httpx.Response:
+def get_item_and_size(item_name: str, item_size: int) -> httpx2.Response:
     """Endpoint with multiple path variables.
 
     Defined after simpler one with same start to make sure pattern matching works. If
@@ -62,11 +62,11 @@ def get_item_and_size(item_name: str, item_size: int) -> httpx.Response:
 
     Also gives a chance to test type-hint interpretation/casting.
     """
-    return httpx.Response(status_code=200, json={"expected": [item_name, item_size]})
+    return httpx2.Response(status_code=200, json={"expected": [item_name, item_size]})
 
 
 @app.post("/items")
-def add_item(request: httpx.Request) -> httpx.Response:
+def add_item(request: httpx2.Request) -> httpx2.Response:
     """Mock endpoint to test getting data from the request body.
 
     Expects "detail" in body.
@@ -90,4 +90,4 @@ def add_item(request: httpx.Request) -> httpx.Response:
             data={},
         )
 
-    return httpx.Response(status_code=201, json={"expected": body["detail"]})
+    return httpx2.Response(status_code=201, json={"expected": body["detail"]})

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -18,6 +18,7 @@
 import asyncio
 import multiprocessing
 import re
+import time
 
 import httpx2
 import pytest
@@ -36,27 +37,75 @@ from tests.integration.fixtures.utils import find_free_port
 pytestmark = pytest.mark.asyncio()
 
 
+SERVER_STARTUP_TIMEOUT = 30.0
+SERVER_POLL_INTERVAL = 0.05
+
+
+def _serve(config: ApiConfigBase) -> None:
+    """Run the test server in a child process.
+
+    Defined at module level rather than as a lambda so that it can be pickled for the
+    "spawn" start method.
+    """
+    asyncio.run(run_server(app=app, config=config))
+
+
+async def _get_when_ready(
+    url: str, process: multiprocessing.Process
+) -> httpx2.Response:
+    """Poll `url` until the server answers, then return its response.
+
+    The server runs in a separate process, so it is not ready the instant the process
+    starts. Polling until it answers (rather than sleeping for a fixed interval) keeps
+    this test from failing on slower or more heavily loaded runners -- notably when
+    pytest is driven by an IDE test runner or with coverage enabled, where process
+    startup takes noticeably longer than it does on a bare command line.
+    """
+    deadline = time.monotonic() + SERVER_STARTUP_TIMEOUT
+    last_error: Exception | None = None
+
+    async with httpx2.AsyncClient() as client:
+        while time.monotonic() < deadline:
+            if not process.is_alive():
+                raise AssertionError(
+                    f"Server process exited before becoming ready "
+                    f"(exit code {process.exitcode})"
+                )
+            try:
+                return await client.get(url)
+            except httpx2.TransportError as error:
+                last_error = error
+                await asyncio.sleep(SERVER_POLL_INTERVAL)
+
+    raise AssertionError(
+        f"Server did not become ready within {SERVER_STARTUP_TIMEOUT}s"
+    ) from last_error
+
+
 async def test_run_server():
     """Test the run_server wrapper function."""
     config = ApiConfigBase()
     config.port = find_free_port()
 
-    process = multiprocessing.Process(
-        target=lambda: asyncio.run(run_server(app=app, config=config))
+    # Use "spawn" rather than the platform default "fork". A forked child inherits the
+    # whole address space of the pytest process, including every open file descriptor.
+    # When pytest is driven by an IDE test runner that streams results back over a
+    # pipe, that child holds a duplicate of the result stream, and killing it mid-run
+    # can cost results for later tests -- which such runners then display as "skipped".
+    # A spawned child is a fresh interpreter and inherits none of it.
+    process = multiprocessing.get_context("spawn").Process(
+        target=_serve, args=(config,)
     )
     process.start()
 
-    # give server time to come up:
-    await asyncio.sleep(2)
-
-    # run test query:
     try:
-        async with httpx2.AsyncClient() as client:
-            response = await client.get(f"http://{config.host}:{config.port}/greet")
-    except Exception as exc:
-        raise exc
+        response = await _get_when_ready(
+            f"http://{config.host}:{config.port}/greet", process
+        )
     finally:
         process.kill()
+        process.join(timeout=10)
+
     assert response.status_code == 200
     assert response.json() == GREETING
 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -16,9 +16,9 @@
 """Test api module."""
 
 import asyncio
-import multiprocessing
 import re
 import time
+from contextlib import suppress
 
 import httpx2
 import pytest
@@ -41,36 +41,16 @@ SERVER_STARTUP_TIMEOUT = 30.0
 SERVER_POLL_INTERVAL = 0.05
 
 
-def _serve(config: ApiConfigBase) -> None:
-    """Run the test server in a child process.
-
-    Defined at module level rather than as a lambda so that it can be pickled for the
-    "spawn" start method.
-    """
-    asyncio.run(run_server(app=app, config=config))
-
-
-async def _get_when_ready(
-    url: str, process: multiprocessing.Process
-) -> httpx2.Response:
-    """Poll `url` until the server answers, then return its response.
-
-    The server runs in a separate process, so it is not ready the instant the process
-    starts. Polling until it answers (rather than sleeping for a fixed interval) keeps
-    this test from failing on slower or more heavily loaded runners -- notably when
-    pytest is driven by an IDE test runner or with coverage enabled, where process
-    startup takes noticeably longer than it does on a bare command line.
-    """
+async def _get_when_ready(url: str, server: asyncio.Task) -> httpx2.Response:
+    """Poll `url` until the server answers, so slow startup doesn't fail the test."""
     deadline = time.monotonic() + SERVER_STARTUP_TIMEOUT
     last_error: Exception | None = None
 
     async with httpx2.AsyncClient() as client:
         while time.monotonic() < deadline:
-            if not process.is_alive():
-                raise AssertionError(
-                    f"Server process exited before becoming ready "
-                    f"(exit code {process.exitcode})"
-                )
+            if server.done():
+                server.result()  # re-raise whatever stopped the server
+                raise AssertionError("Server stopped before becoming ready")
             try:
                 return await client.get(url)
             except httpx2.TransportError as error:
@@ -87,24 +67,17 @@ async def test_run_server():
     config = ApiConfigBase()
     config.port = find_free_port()
 
-    # Use "spawn" rather than the platform default "fork". A forked child inherits the
-    # whole address space of the pytest process, including every open file descriptor.
-    # When pytest is driven by an IDE test runner that streams results back over a
-    # pipe, that child holds a duplicate of the result stream, and killing it mid-run
-    # can cost results for later tests -- which such runners then display as "skipped".
-    # A spawned child is a fresh interpreter and inherits none of it.
-    process = multiprocessing.get_context("spawn").Process(
-        target=_serve, args=(config,)
-    )
-    process.start()
-
+    # run_server deliberately serves on the caller's event loop, so run it as a task
+    # here; cancelling it also exercises its graceful-shutdown path.
+    server = asyncio.create_task(run_server(app=app, config=config))
     try:
         response = await _get_when_ready(
-            f"http://{config.host}:{config.port}/greet", process
+            f"http://{config.host}:{config.port}/greet", server
         )
     finally:
-        process.kill()
-        process.join(timeout=10)
+        server.cancel()
+        with suppress(asyncio.CancelledError):
+            await server
 
     assert response.status_code == 200
     assert response.json() == GREETING

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -19,7 +19,7 @@ import asyncio
 import multiprocessing
 import re
 
-import httpx
+import httpx2
 import pytest
 from fastapi import FastAPI
 
@@ -51,7 +51,7 @@ async def test_run_server():
 
     # run test query:
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx2.AsyncClient() as client:
             response = await client.get(f"http://{config.host}:{config.port}/greet")
     except Exception as exc:
         raise exc

--- a/tests/integration/test_correlation.py
+++ b/tests/integration/test_correlation.py
@@ -19,7 +19,7 @@
 from contextlib import nullcontext
 from uuid import UUID
 
-import httpx
+import httpx2
 import pytest
 from fastapi import FastAPI, Request, Response
 from hexkit.correlation import (
@@ -209,7 +209,7 @@ async def test_async_client(generate_correlation_id: bool):
     # Create an AsyncClient instance (NOT AsyncTestClient!)
     async with AsyncClient(
         generate_correlation_id=generate_correlation_id,
-        transport=httpx.ASGITransport(app=app),
+        transport=httpx2.ASGITransport(app=app),
         base_url="http://localhost:8080",
     ) as client:
         # Verify behavior outside of a CID context

--- a/tests/integration/test_httpyexpect_client.py
+++ b/tests/integration/test_httpyexpect_client.py
@@ -103,12 +103,12 @@ def test_typical_client_usage(
         translator.raise_for_error()
 
 
-def test_compatibility_with_httpx():
-    """Make sure that our Response protocol is compatible with the httpx library."""
-    from httpx import Response as HttpxResponse  # noqa: PLC0415
+def test_compatibility_with_httpx2():
+    """Make sure that our Response protocol is compatible with the httpx2 library."""
+    from httpx2 import Response as httpx2Response  # noqa: PLC0415
 
-    httpx_response = HttpxResponse(status_code=200, content=b'{"hello": "world"}')
-    response: Response = httpx_response  # mypy should not complain here
+    httpx2_response = httpx2Response(status_code=200, content=b'{"hello": "world"}')
+    response: Response = httpx2_response  # mypy should not complain here
     assert response.status_code == 200
     assert response.json() == {"hello": "world"}
 

--- a/tests/integration/test_httpyexpect_client.py
+++ b/tests/integration/test_httpyexpect_client.py
@@ -105,9 +105,9 @@ def test_typical_client_usage(
 
 def test_compatibility_with_httpx2():
     """Make sure that our Response protocol is compatible with the httpx2 library."""
-    from httpx2 import Response as httpx2Response  # noqa: PLC0415
+    from httpx2 import Response as Httpx2Response  # noqa: PLC0415
 
-    httpx2_response = httpx2Response(status_code=200, content=b'{"hello": "world"}')
+    httpx2_response = Httpx2Response(status_code=200, content=b'{"hello": "world"}')
     response: Response = httpx2_response  # mypy should not complain here
     assert response.status_code == 200
     assert response.json() == {"hello": "world"}

--- a/tests/integration/test_mock_router.py
+++ b/tests/integration/test_mock_router.py
@@ -18,62 +18,53 @@
 
 from __future__ import annotations
 
-import httpx
+import httpx2
 import pytest
 from fastapi import HTTPException
-from pytest_httpx import HTTPXMock, httpx_mock  # noqa: F401
 
-from ghga_service_commons.api.mock_router import (  # noqa: F401
-    MockRouter,
-    assert_all_responses_were_requested,
-)
+from ghga_service_commons.api.mock_router import MockRouter
 from ghga_service_commons.httpyexpect.server.exceptions import HttpException
 from tests.integration.fixtures.mock_api import app
 
 BASE_URL = "http://localhost"
 
 
-def http_exception_handler(request: httpx.Request, exc: HttpException):
+def http_exception_handler(request: httpx2.Request, exc: HttpException):
     """Define an exception handler that can be attached to the MockRouter."""
     assert isinstance(exc, HttpException)
-    return httpx.Response(
+    return httpx2.Response(
         status_code=exc.status_code,
         json=exc.body.model_dump(),
     )
 
 
-def test_non_existent_path(httpx_mock: HTTPXMock):  # noqa: F811
+def test_non_existent_path():
     """Make a request with a path that isn't registered."""
-    httpx_mock.add_callback(callback=app.handle_request)
     with pytest.raises(HttpException):
-        with httpx.Client(base_url=BASE_URL) as client:
+        with httpx2.Client(base_url=BASE_URL, transport=app.as_transport()) as client:
             client.get("/does/not/exist")
 
 
-def test_url_with_wrong_method(httpx_mock: HTTPXMock):  # noqa: F811
+def test_url_with_wrong_method():
     """Make a request to a url that is registered but with the wrong method."""
-    httpx_mock.add_callback(callback=app.handle_request)
     with pytest.raises(HttpException):
-        with httpx.Client(base_url=BASE_URL) as client:
+        with httpx2.Client(base_url=BASE_URL, transport=app.as_transport()) as client:
             client.patch("/hello")
 
 
-def test_simplest_get(httpx_mock: HTTPXMock):  # noqa: F811
+def test_simplest_get():
     """Make sure there's nothing wrong with an endpoint path with no variables."""
-    httpx_mock.add_callback(callback=app.handle_request)
-    with httpx.Client(base_url=BASE_URL) as client:
+    with httpx2.Client(base_url=BASE_URL, transport=app.as_transport()) as client:
         response = client.get("/hello")
         assert response is not None
         assert response.json() == {"hello": "world"}
 
 
-def test_get_one_path_variable(httpx_mock: HTTPXMock):  # noqa: F811
+def test_get_one_path_variable():
     """Verify that a path terminating with one variable is okay."""
-    httpx_mock.add_callback(callback=app.handle_request)
-
     expected = "beach_ball"
 
-    with httpx.Client(base_url=BASE_URL) as client:
+    with httpx2.Client(base_url=BASE_URL, transport=app.as_transport()) as client:
         response = client.get(f"/items/{expected}")
         assert response is not None
         body = response.json()
@@ -81,14 +72,12 @@ def test_get_one_path_variable(httpx_mock: HTTPXMock):  # noqa: F811
         assert body["expected"] == expected
 
 
-def test_get_two_path_variables(httpx_mock: HTTPXMock):  # noqa: F811
+def test_get_two_path_variables():
     """Make sure the handler can parse paths with more than one variable."""
-    httpx_mock.add_callback(callback=app.handle_request)
-
     # pass str number as a sanity check that it stays a str
     expected = ["4", 9]
 
-    with httpx.Client(base_url=BASE_URL) as client:
+    with httpx2.Client(base_url=BASE_URL, transport=app.as_transport()) as client:
         response = client.get(f"/items/{expected[0]}/sizes/{expected[1]}")
         assert response is not None
         body = response.json()
@@ -96,28 +85,24 @@ def test_get_two_path_variables(httpx_mock: HTTPXMock):  # noqa: F811
         assert body["expected"] == expected
 
 
-def test_get_with_bad_input(httpx_mock: HTTPXMock):  # noqa: F811
+def test_get_with_bad_input():
     """Look for error raised with invalid path variables."""
-    httpx_mock.add_callback(callback=app.handle_request)
-
     expected = ["pass", "fail"]
 
     with pytest.raises(HttpException):
-        with httpx.Client(base_url=BASE_URL) as client:
+        with httpx2.Client(base_url=BASE_URL, transport=app.as_transport()) as client:
             client.get(f"/items/{expected[0]}/sizes/{expected[1]}")
 
 
-def test_post_successful(httpx_mock: HTTPXMock):  # noqa: F811
+def test_post_successful():
     """Pass a vanilla POST request.
 
     Makes sure that the request parameter is correctly passed to the endpoint function.
     """
-    httpx_mock.add_callback(callback=app.handle_request)
-
     request_body = {"detail": {"a key": "a value"}}
     expected = request_body["detail"]
 
-    with httpx.Client(base_url=BASE_URL) as client:
+    with httpx2.Client(base_url=BASE_URL, transport=app.as_transport()) as client:
         response = client.post("/items", json=request_body)
         assert response is not None
 
@@ -126,30 +111,27 @@ def test_post_successful(httpx_mock: HTTPXMock):  # noqa: F811
         assert body["expected"] == expected
 
 
-def test_post_failure(httpx_mock: HTTPXMock):  # noqa: F811
+def test_post_failure():
     """Cause the endpoint to raise an HttpException.
 
     Makes sure that endpoint-defined exceptions are passed up as expected when no
     exception handler is specified.
     """
-    httpx_mock.add_callback(callback=app.handle_request)
-
     # cause a failure by omitting the "detail" key that the endpoint looks for
     with pytest.raises(HttpException):
-        with httpx.Client(base_url=BASE_URL) as client:
+        with httpx2.Client(base_url=BASE_URL, transport=app.as_transport()) as client:
             client.post("/items", json={})
 
 
-def test_post_failure_with_handler(httpx_mock: HTTPXMock):  # noqa: F811
+def test_post_failure_with_handler():
     """Cause the endpoint to raise an HttpException.
 
     Makes sure that exceptions are handled with the specified handler.
     """
     app.exception_handler = http_exception_handler
-    httpx_mock.add_callback(callback=app.handle_request)
 
     # cause a failure by omitting the "detail" key that the endpoint looks for
-    with httpx.Client(base_url=BASE_URL) as client:
+    with httpx2.Client(base_url=BASE_URL, transport=app.as_transport()) as client:
         client.post("/items", json={})
 
 
@@ -187,7 +169,7 @@ def test_endpoint_missing_typehint():
             """Define a dummy function with missing type-hint info."""
 
 
-def test_handler_errors_filtering(httpx_mock: HTTPXMock):  # noqa: F811
+def test_handler_errors_filtering():
     """Make sure only the specified errors are passed to the handler.
 
     When a handler is provided and errors are specified,
@@ -197,8 +179,8 @@ def test_handler_errors_filtering(httpx_mock: HTTPXMock):  # noqa: F811
     class TestValueError(ValueError):
         """Subclass of ValueError to test handle_exception_subclasses."""
 
-    def handler(request: httpx.Request, exc: ValueError | TestValueError):
-        return httpx.Response(status_code=500)
+    def handler(request: httpx2.Request, exc: ValueError | TestValueError):
+        return httpx2.Response(status_code=500)
 
     throwaway: MockRouter = MockRouter(
         exception_handler=handler,
@@ -219,9 +201,7 @@ def test_handler_errors_filtering(httpx_mock: HTTPXMock):  # noqa: F811
     def fails_also():  # will only get passed to error if we set handle_exception_subclasses
         raise TestValueError()
 
-    httpx_mock.add_callback(callback=throwaway.handle_request, is_reusable=True)
-
-    with httpx.Client(base_url=BASE_URL) as client:
+    with httpx2.Client(base_url=BASE_URL, transport=throwaway.as_transport()) as client:
         client.get("/gotohandler")
         with pytest.raises(HttpException):
             client.get("/raise")
@@ -232,7 +212,7 @@ def test_handler_errors_filtering(httpx_mock: HTTPXMock):  # noqa: F811
         client.get("/raise2")
 
 
-def test_exceptions_no_handler(httpx_mock: HTTPXMock):  # noqa: F811
+def test_exceptions_no_handler():
     """Test exception handlers.
 
     Errors specified in exceptions_to_handle should be raised normally if
@@ -246,18 +226,16 @@ def test_exceptions_no_handler(httpx_mock: HTTPXMock):  # noqa: F811
     def raise_an_error():
         raise HTTPException(status_code=404)
 
-    httpx_mock.add_callback(callback=throwaway.handle_request)
-
-    with httpx.Client(base_url=BASE_URL) as client:
+    with httpx2.Client(base_url=BASE_URL, transport=throwaway.as_transport()) as client:
         with pytest.raises(HTTPException):
             client.get("/")
 
 
-def test_no_exceptions_specified(httpx_mock: HTTPXMock):  # noqa: F811
+def test_no_exceptions_specified():
     """Make sure nothing is passed to the error handler if we omit exceptions_to_handle."""
 
-    def handler(request: httpx.Request, exc: HTTPException):
-        return httpx.Response(status_code=500)
+    def handler(request: httpx2.Request, exc: HTTPException):
+        return httpx2.Response(status_code=500)
 
     throwaway: MockRouter = MockRouter(exception_handler=handler)
 
@@ -265,8 +243,6 @@ def test_no_exceptions_specified(httpx_mock: HTTPXMock):  # noqa: F811
     def raise_an_error():
         raise HTTPException(status_code=404)
 
-    httpx_mock.add_callback(callback=throwaway.handle_request)
-
-    with httpx.Client(base_url=BASE_URL) as client:
+    with httpx2.Client(base_url=BASE_URL, transport=throwaway.as_transport()) as client:
         with pytest.raises(HTTPException):
             client.get("/")

--- a/tests/integration/test_uvicorn_logs.py
+++ b/tests/integration/test_uvicorn_logs.py
@@ -40,14 +40,9 @@ EXPECTED_FIELDS = {
 
 @pytest.fixture
 def restore_root_logging():
-    """Restore the root logger after a test reconfigures logging globally.
+    """Undo the global root logger changes made by `configure_logging`.
 
-    `configure_logging` mutates the root logger and binds a handler to whatever
-    `sys.stderr` is at call time. Under `capsys` that is a capture buffer which pytest
-    closes during teardown, so leaving the handler installed would point the root
-    logger at a closed stream for the rest of the session -- every later log record
-    would then raise inside logging and spew to stderr. It also raises the root level,
-    which makes those later records more frequent.
+    Under `capsys` it binds a handler to a capture buffer that pytest later closes.
     """
     root = logging.getLogger()
     saved_handlers = root.handlers[:]

--- a/tests/integration/test_uvicorn_logs.py
+++ b/tests/integration/test_uvicorn_logs.py
@@ -50,9 +50,6 @@ def restore_root_logging():
     try:
         yield
     finally:
-        for handler in root.handlers[:]:
-            if handler not in saved_handlers:
-                root.removeHandler(handler)
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
 

--- a/tests/integration/test_uvicorn_logs.py
+++ b/tests/integration/test_uvicorn_logs.py
@@ -17,6 +17,7 @@
 
 import asyncio
 import json
+import logging
 from contextlib import suppress
 
 import pytest
@@ -37,8 +38,32 @@ EXPECTED_FIELDS = {
 }
 
 
+@pytest.fixture
+def restore_root_logging():
+    """Restore the root logger after a test reconfigures logging globally.
+
+    `configure_logging` mutates the root logger and binds a handler to whatever
+    `sys.stderr` is at call time. Under `capsys` that is a capture buffer which pytest
+    closes during teardown, so leaving the handler installed would point the root
+    logger at a closed stream for the rest of the session -- every later log record
+    would then raise inside logging and spew to stderr. It also raises the root level,
+    which makes those later records more frequent.
+    """
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    try:
+        yield
+    finally:
+        for handler in root.handlers[:]:
+            if handler not in saved_handlers:
+                root.removeHandler(handler)
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+
+
 @pytest.mark.asyncio
-async def test_uvicorn_log_format(capsys):
+async def test_uvicorn_log_format(capsys, restore_root_logging):
     """Verify that the uvicorn logs are formatted with the configured logging."""
     test_app = FastAPI()
     config = ApiConfigBase()

--- a/tests/unit/transports/test_factory.py
+++ b/tests/unit/transports/test_factory.py
@@ -15,12 +15,15 @@
 
 """Tests for the transport factory, including SSL verification handling."""
 
-import shutil
 import ssl
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-import certifi
 import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
 from httpx2 import AsyncHTTPTransport
 
 from ghga_service_commons.transports.config import CompositeConfig
@@ -31,12 +34,46 @@ from ghga_service_commons.transports.factory import (
 from ghga_service_commons.transports.ratelimiting import AsyncRateLimitingTransport
 from ghga_service_commons.transports.retry import AsyncRetryTransport
 
+CA_BUNDLE_CERT_COUNT = 3
+
+
+def throwaway_ca_pem(common_name: str) -> bytes:
+    """Generate a throwaway, self-signed CA certificate as PEM bytes."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    now = datetime.now(timezone.utc)
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(days=1))
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    return certificate.public_bytes(serialization.Encoding.PEM)
+
 
 @pytest.fixture
 def ca_bundle(tmp_path: Path) -> Path:
-    """Provide a path to a real, loadable CA bundle copied into a temp dir."""
+    """Provide a loadable CA bundle of several throwaway certificates."""
     bundle = tmp_path / "ca-bundle.pem"
-    shutil.copyfile(certifi.where(), bundle)
+    bundle.write_bytes(
+        b"".join(
+            throwaway_ca_pem(f"Test CA {number}")
+            for number in range(CA_BUNDLE_CERT_COUNT)
+        )
+    )
+    return bundle
+
+
+@pytest.fixture
+def single_cert_bundle(tmp_path: Path) -> Path:
+    """Provide a loadable CA bundle holding exactly one throwaway certificate."""
+    bundle = tmp_path / "single-cert.pem"
+    bundle.write_bytes(throwaway_ca_pem("Test CA single"))
     return bundle
 
 
@@ -63,7 +100,10 @@ def test_get_ssl_verify_ssl_cert_file(monkeypatch: pytest.MonkeyPatch, ca_bundle
 
 
 def test_get_ssl_verify_neither_set(monkeypatch: pytest.MonkeyPatch):
-    """Neither env var set -> returns True (httpx2 default = certifi)."""
+    """Neither env var set -> returns True, leaving httpx2 its own default.
+
+    That default is the OS trust store via truststore, not certifi as in httpx 0.x.
+    """
     monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
     monkeypatch.delenv("SSL_CERT_FILE", raising=False)
 
@@ -73,28 +113,22 @@ def test_get_ssl_verify_neither_set(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_get_ssl_verify_requests_ca_bundle_precedence(
-    monkeypatch: pytest.MonkeyPatch, ca_bundle: Path, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, ca_bundle: Path, single_cert_bundle: Path
 ):
     """Both set and both loadable -> REQUESTS_CA_BUNDLE wins over SSL_CERT_FILE.
 
-    Both env vars point to valid, loadable bundles that differ in content, so the
-    loaded CA set identifies which file was actually used: the full certifi bundle
-    (REQUESTS_CA_BUNDLE) versus a single-cert subset (SSL_CERT_FILE).
+    Both env vars point to valid, loadable bundles that differ in the number of
+    certificates they hold, so the loaded CA set identifies which file was actually
+    used: the multi-cert bundle (REQUESTS_CA_BUNDLE) or the single-cert one
+    (SSL_CERT_FILE).
     """
-    single_cert_bundle = tmp_path / "single-cert.pem"
-    marker = "-----END CERTIFICATE-----"
-    first_cert = ca_bundle.read_text().split(marker)[0] + marker + "\n"
-    single_cert_bundle.write_text(first_cert)
-
     monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(ca_bundle))
     monkeypatch.setenv("SSL_CERT_FILE", str(single_cert_bundle))
 
     verify = get_ssl_verify()
 
     assert isinstance(verify, ssl.SSLContext)
-    expected = ssl.create_default_context(cafile=str(ca_bundle))
-    assert len(verify.get_ca_certs()) == len(expected.get_ca_certs())
-    assert len(verify.get_ca_certs()) > 1
+    assert len(verify.get_ca_certs()) == CA_BUNDLE_CERT_COUNT
 
 
 def test_create_ratelimiting_retry_transport_layers_transports():

--- a/tests/unit/transports/test_factory.py
+++ b/tests/unit/transports/test_factory.py
@@ -21,10 +21,9 @@ from pathlib import Path
 
 import certifi
 import pytest
-from hishel.httpx import AsyncCacheTransport
-from httpx import AsyncHTTPTransport
+from httpx2 import AsyncHTTPTransport
 
-from ghga_service_commons.transports.config import CompositeCacheConfig, CompositeConfig
+from ghga_service_commons.transports.config import CompositeConfig
 from ghga_service_commons.transports.factory import (
     CompositeTransportFactory,
     get_ssl_verify,
@@ -64,7 +63,7 @@ def test_get_ssl_verify_ssl_cert_file(monkeypatch: pytest.MonkeyPatch, ca_bundle
 
 
 def test_get_ssl_verify_neither_set(monkeypatch: pytest.MonkeyPatch):
-    """Neither env var set -> returns True (httpx default = certifi)."""
+    """Neither env var set -> returns True (httpx2 default = certifi)."""
     monkeypatch.delenv("REQUESTS_CA_BUNDLE", raising=False)
     monkeypatch.delenv("SSL_CERT_FILE", raising=False)
 
@@ -121,15 +120,3 @@ def test_create_ratelimiting_retry_transport_uses_custom_base():
     ratelimiting = transport._transport
     assert isinstance(ratelimiting, AsyncRateLimitingTransport)
     assert ratelimiting._transport is base
-
-
-def test_create_cached_ratelimiting_retry_transport_layers_transports():
-    """The cache transport wraps the retry and rate limiting transports."""
-    transport = CompositeTransportFactory.create_cached_ratelimiting_retry_transport(
-        CompositeCacheConfig()
-    )
-
-    assert isinstance(transport, AsyncCacheTransport)
-    retry = transport.next_transport
-    assert isinstance(retry, AsyncRetryTransport)
-    assert isinstance(retry._transport, AsyncRateLimitingTransport)

--- a/tests/unit/transports/test_proxy_handling.py
+++ b/tests/unit/transports/test_proxy_handling.py
@@ -19,15 +19,11 @@
 from collections.abc import Callable
 from unittest.mock import AsyncMock, patch
 
-import httpx
+import httpx2
 import pytest
-from hishel.httpx import AsyncCacheTransport
 
-from ghga_service_commons.transports.config import CompositeCacheConfig, CompositeConfig
-from ghga_service_commons.transports.proxy_handling import (
-    cached_ratelimiting_retry_proxies,
-    ratelimiting_retry_proxies,
-)
+from ghga_service_commons.transports.config import CompositeConfig
+from ghga_service_commons.transports.proxy_handling import ratelimiting_retry_proxies
 from ghga_service_commons.transports.retry import AsyncRetryTransport
 
 # Protocol keys used in proxy configuration
@@ -62,11 +58,6 @@ MULTI_PROXY_CONFIG = {
     "config_class,proxy_fn,expected_transport",
     [
         (CompositeConfig, ratelimiting_retry_proxies, AsyncRetryTransport),
-        (
-            CompositeCacheConfig,
-            cached_ratelimiting_retry_proxies,
-            AsyncCacheTransport,
-        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -74,9 +65,9 @@ MULTI_PROXY_CONFIG = {
     [*MULTI_PROXY_CONFIG.items()],
 )
 def test_with_single_proxy(
-    config_class: type[CompositeConfig | CompositeCacheConfig],
+    config_class: type[CompositeConfig],
     proxy_fn: Callable,
-    expected_transport: type[AsyncRetryTransport | AsyncCacheTransport],
+    expected_transport: type[AsyncRetryTransport],
     protocol_key: str,
     proxy_url: str,
 ):
@@ -97,17 +88,12 @@ def test_with_single_proxy(
     "config_class,proxy_fn,expected_transport",
     [
         (CompositeConfig, ratelimiting_retry_proxies, AsyncRetryTransport),
-        (
-            CompositeCacheConfig,
-            cached_ratelimiting_retry_proxies,
-            AsyncCacheTransport,
-        ),
     ],
 )
 def test_with_multiple_proxies(
-    config_class: type[CompositeConfig | CompositeCacheConfig],
+    config_class: type[CompositeConfig],
     proxy_fn: Callable,
-    expected_transport: type[AsyncRetryTransport | AsyncCacheTransport],
+    expected_transport: type[AsyncRetryTransport],
 ):
     """Test that multiple proxy protocols are configured together."""
     config = config_class()
@@ -131,11 +117,10 @@ def test_with_multiple_proxies(
     "config_class,proxy_fn",
     [
         (CompositeConfig, ratelimiting_retry_proxies),
-        (CompositeCacheConfig, cached_ratelimiting_retry_proxies),
     ],
 )
 def test_with_no_proxies(
-    config_class: type[CompositeConfig | CompositeCacheConfig],
+    config_class: type[CompositeConfig],
     proxy_fn: Callable,
 ):
     """Test that empty dict is returned when no proxies are configured."""
@@ -154,17 +139,16 @@ def test_with_no_proxies(
     "config_class,proxy_fn",
     [
         (CompositeConfig, ratelimiting_retry_proxies),
-        (CompositeCacheConfig, cached_ratelimiting_retry_proxies),
     ],
 )
 def test_preserves_no_proxy_values(
-    config_class: type[CompositeConfig | CompositeCacheConfig],
+    config_class: type[CompositeConfig],
     proxy_fn: Callable,
 ):
     """NO_PROXY hosts (None values) are preserved as ``None`` mounts.
 
-    httpx's built-in NO_PROXY handling is bypassed when ``mounts`` are supplied, so
-    the ``None`` entries are what tell httpx to connect directly for those hosts.
+    httpx2's built-in NO_PROXY handling is bypassed when ``mounts`` are supplied, so
+    the ``None`` entries are what tell httpx2 to connect directly for those hosts.
     They must be kept as keys with ``None`` values, not dropped and not wrapped in
     a transport.
     """
@@ -192,7 +176,6 @@ def test_preserves_no_proxy_values(
     "config_class,proxy_fn",
     [
         (CompositeConfig, ratelimiting_retry_proxies),
-        (CompositeCacheConfig, cached_ratelimiting_retry_proxies),
     ],
 )
 @pytest.mark.parametrize(
@@ -220,7 +203,7 @@ def test_preserves_no_proxy_values(
 )
 @pytest.mark.asyncio
 async def test_with_proxy_mount(
-    config_class: type[CompositeConfig | CompositeCacheConfig],
+    config_class: type[CompositeConfig],
     proxy_fn: Callable,
     protocol_key: str,
     proxy_url: str,
@@ -236,7 +219,7 @@ async def test_with_proxy_mount(
     ):
         mounts = proxy_fn(config)
 
-        mock_response = httpx.Response(
+        mock_response = httpx2.Response(
             status_code=200,
             content=expected_response,
         )
@@ -247,7 +230,7 @@ async def test_with_proxy_mount(
             new_callable=AsyncMock,
             return_value=mock_response,
         ):
-            async with httpx.AsyncClient(mounts=mounts) as client:
+            async with httpx2.AsyncClient(mounts=mounts) as client:
                 response = await client.get(request_url)
 
                 assert response.status_code == 200
@@ -256,14 +239,13 @@ async def test_with_proxy_mount(
                 transport = mounts[protocol_key]
                 transport.handle_async_request.assert_called()
                 # check the proxy base transports were wrapped
-                assert isinstance(transport, (AsyncRetryTransport, AsyncCacheTransport))
+                assert isinstance(transport, AsyncRetryTransport)
 
 
 @pytest.mark.parametrize(
     "config_class,proxy_fn",
     [
         (CompositeConfig, ratelimiting_retry_proxies),
-        (CompositeCacheConfig, cached_ratelimiting_retry_proxies),
     ],
 )
 @pytest.mark.parametrize(
@@ -279,7 +261,7 @@ async def test_with_proxy_mount(
 )
 @pytest.mark.asyncio
 async def test_not_hitting_proxy_mount(
-    config_class: type[CompositeConfig | CompositeCacheConfig],
+    config_class: type[CompositeConfig],
     proxy_fn: Callable,
     protocol_key: str,
     proxy_url: str,
@@ -295,7 +277,7 @@ async def test_not_hitting_proxy_mount(
     ):
         mounts = proxy_fn(config)
 
-        mock_response = httpx.Response(
+        mock_response = httpx2.Response(
             status_code=200,
             content=expected_response,
         )
@@ -306,6 +288,6 @@ async def test_not_hitting_proxy_mount(
             new_callable=AsyncMock,
             return_value=mock_response,
         ):
-            async with httpx.AsyncClient(mounts=mounts) as client:
+            async with httpx2.AsyncClient(mounts=mounts) as client:
                 await client.get(request_url)
                 mounts[protocol_key].handle_async_request.assert_not_called()

--- a/tests/unit/transports/test_ratelimiting.py
+++ b/tests/unit/transports/test_ratelimiting.py
@@ -17,7 +17,7 @@
 
 from unittest.mock import AsyncMock, patch
 
-import httpx
+import httpx2
 import pytest
 
 from ghga_service_commons.transports.config import RateLimitingTransportConfig
@@ -26,12 +26,12 @@ from ghga_service_commons.transports.ratelimiting import AsyncRateLimitingTransp
 # The per-request sleep is drawn from random.uniform keeps the real sleep at zero
 # while exposing the delay the transport computed.
 UNIFORM = "ghga_service_commons.transports.ratelimiting.random.uniform"
-_REQUEST = httpx.Request("GET", "http://test")
+_REQUEST = httpx2.Request("GET", "http://test")
 
 
-def _mock_transport(responses: list[httpx.Response]) -> AsyncMock:
+def _mock_transport(responses: list[httpx2.Response]) -> AsyncMock:
     """Build a transport mock returning the given responses in turn."""
-    transport = AsyncMock(spec=httpx.AsyncBaseTransport)
+    transport = AsyncMock(spec=httpx2.AsyncBaseTransport)
     transport.handle_async_request = AsyncMock(side_effect=responses)
     return transport
 
@@ -46,7 +46,7 @@ def _ratelimiter(transport: AsyncMock, **config_kwargs) -> AsyncRateLimitingTran
 @pytest.mark.asyncio
 async def test_passes_through_non_429_response():
     """Ensure non-429 responses are returned unchanged without a Should-Wait header."""
-    response = httpx.Response(httpx.codes.OK)
+    response = httpx2.Response(httpx2.codes.OK)
     ratelimiter = _ratelimiter(_mock_transport([response]))
 
     result = await ratelimiter.handle_async_request(_REQUEST)
@@ -58,7 +58,7 @@ async def test_passes_through_non_429_response():
 @pytest.mark.asyncio
 async def test_429_with_retry_after_sets_wait_time():
     """Ensure a 429 with a Retry-After header stores the wait time and does not signal Should-Wait."""
-    response = httpx.Response(429, headers={"Retry-After": "5"})
+    response = httpx2.Response(429, headers={"Retry-After": "5"})
     ratelimiter = _ratelimiter(_mock_transport([response]))
 
     result = await ratelimiter.handle_async_request(_REQUEST)
@@ -70,7 +70,7 @@ async def test_429_with_retry_after_sets_wait_time():
 @pytest.mark.asyncio
 async def test_429_without_retry_after_sets_should_wait_header():
     """Ensure a 429 without a Retry-After header signals Should-Wait and stores no wait time."""
-    response = httpx.Response(429)
+    response = httpx2.Response(429)
     ratelimiter = _ratelimiter(_mock_transport([response]))
 
     result = await ratelimiter.handle_async_request(_REQUEST)
@@ -83,8 +83,8 @@ async def test_429_without_retry_after_sets_should_wait_header():
 async def test_carried_over_wait_time_is_applied_to_next_request():
     """Ensure a wait time learned from a 429 is applied as the delay before the next request."""
     responses = [
-        httpx.Response(429, headers={"Retry-After": "10"}),
-        httpx.Response(httpx.codes.OK),
+        httpx2.Response(429, headers={"Retry-After": "10"}),
+        httpx2.Response(httpx2.codes.OK),
     ]
     ratelimiter = _ratelimiter(_mock_transport(responses))
 
@@ -104,7 +104,7 @@ async def test_carried_over_wait_time_is_applied_to_next_request():
 async def test_wait_time_reset_after_configured_requests():
     """Ensure stored wait time is cleared once the configured number of requests has passed."""
     ratelimiter = _ratelimiter(
-        _mock_transport([httpx.Response(httpx.codes.OK)] * 2),
+        _mock_transport([httpx2.Response(httpx2.codes.OK)] * 2),
         retry_after_applicable_for_num_requests=2,
     )
     # Simulate a wait time still in effect from a previous Retry-After response.

--- a/tests/unit/transports/test_retry.py
+++ b/tests/unit/transports/test_retry.py
@@ -19,7 +19,7 @@ import logging
 from collections.abc import Callable
 from unittest.mock import AsyncMock
 
-import httpx
+import httpx2
 import pytest
 from tenacity import AsyncRetrying, RetryCallState, RetryError
 
@@ -33,10 +33,10 @@ from ghga_service_commons.transports.retry import (
 
 LOGGER_NAME = "ghga_service_commons.transports.retry"
 RETRYABLE_STATUS_CODE = 503
-_REQUEST = httpx.Request("GET", "http://test")
+_REQUEST = httpx2.Request("GET", "http://test")
 
 
-class _TrackedResponse(httpx.Response):
+class _TrackedResponse(httpx2.Response):
     """Response that records whether it was closed, to detect leaked connections."""
 
     def __init__(self, status_code: int) -> None:
@@ -48,7 +48,7 @@ class _TrackedResponse(httpx.Response):
         await super().aclose()
 
 
-class _FailingCloseResponse(httpx.Response):
+class _FailingCloseResponse(httpx2.Response):
     """Response whose aclose() always raises, to exercise cleanup error handling.
 
     Counts close calls so tests can assert the same response is not closed twice.
@@ -70,7 +70,7 @@ def _no_wait(config: RetryTransportConfig) -> Callable[[RetryCallState], float]:
 
 def _mock_transport(side_effect: list[object]) -> AsyncMock:
     """Build a transport mock whose calls yield the given responses/exceptions in turn."""
-    transport = AsyncMock(spec=httpx.AsyncBaseTransport)
+    transport = AsyncMock(spec=httpx2.AsyncBaseTransport)
     transport.handle_async_request = AsyncMock(side_effect=side_effect)
     return transport
 
@@ -91,7 +91,7 @@ def _retry_transport(
 
 def _retry_state(
     *,
-    result: httpx.Response | None = None,
+    result: httpx2.Response | None = None,
     exception: BaseException | None = None,
     attempt_number: int = 1,
     fn: Callable[..., object] | None = None,
@@ -113,7 +113,7 @@ def _named_function() -> None:
 @pytest.mark.asyncio
 async def test_returns_first_successful_response():
     """Ensure a non-retryable success is returned immediately without a second attempt."""
-    response = _TrackedResponse(httpx.codes.OK)
+    response = _TrackedResponse(httpx2.codes.OK)
     transport = _mock_transport([response])
 
     result = await _retry_transport(transport).handle_async_request(_REQUEST)
@@ -129,7 +129,7 @@ async def test_retries_retryable_status_until_success():
     responses = [
         _TrackedResponse(RETRYABLE_STATUS_CODE),
         _TrackedResponse(RETRYABLE_STATUS_CODE),
-        _TrackedResponse(httpx.codes.OK),
+        _TrackedResponse(httpx2.codes.OK),
     ]
     transport = _mock_transport(responses)  # type: ignore[arg-type]
 
@@ -142,7 +142,7 @@ async def test_retries_retryable_status_until_success():
 @pytest.mark.asyncio
 async def test_does_not_retry_non_retryable_status():
     """Ensure a non-retryable status code is returned as-is after a single attempt."""
-    response = _TrackedResponse(httpx.codes.NOT_FOUND)
+    response = _TrackedResponse(httpx2.codes.NOT_FOUND)
     transport = _mock_transport([response])
 
     result = await _retry_transport(transport).handle_async_request(_REQUEST)
@@ -155,16 +155,16 @@ async def test_does_not_retry_non_retryable_status():
 @pytest.mark.parametrize(
     "exception",
     [
-        httpx.ConnectTimeout("timeout"),
-        httpx.ConnectError("network"),
-        httpx.RemoteProtocolError("protocol"),
-        httpx.ProxyError("proxy"),
+        httpx2.ConnectTimeout("timeout"),
+        httpx2.ConnectError("network"),
+        httpx2.RemoteProtocolError("protocol"),
+        httpx2.ProxyError("proxy"),
     ],
 )
 @pytest.mark.asyncio
 async def test_retries_on_retryable_exception(exception: Exception):
     """Ensure configured retryable exception types trigger a retry that can then succeed."""
-    response = _TrackedResponse(httpx.codes.OK)
+    response = _TrackedResponse(httpx2.codes.OK)
     transport = _mock_transport([exception, response])
 
     result = await _retry_transport(transport).handle_async_request(_REQUEST)
@@ -187,9 +187,9 @@ async def test_does_not_retry_unlisted_exception():
 @pytest.mark.asyncio
 async def test_reraises_original_exception_when_configured():
     """Ensure with reraise enabled the original exception surfaces after retries are exhausted."""
-    transport = _mock_transport([httpx.ConnectError("c")] * 3)
+    transport = _mock_transport([httpx2.ConnectError("c")] * 3)
 
-    with pytest.raises(httpx.ConnectError):
+    with pytest.raises(httpx2.ConnectError):
         await _retry_transport(
             transport, num_retries=3, reraise=True
         ).handle_async_request(_REQUEST)
@@ -200,7 +200,7 @@ async def test_reraises_original_exception_when_configured():
 @pytest.mark.asyncio
 async def test_raises_retry_error_when_not_reraising():
     """Ensure with reraise disabled the exhausted exception is wrapped in a RetryError."""
-    exception = httpx.ConnectError("c")
+    exception = httpx2.ConnectError("c")
     transport = _mock_transport([exception] * 3)
 
     with pytest.raises(RetryError) as exc_info:
@@ -223,7 +223,7 @@ async def test_retried_responses_are_closed():
     responses = [
         _TrackedResponse(RETRYABLE_STATUS_CODE),
         _TrackedResponse(RETRYABLE_STATUS_CODE),
-        _TrackedResponse(httpx.codes.OK),
+        _TrackedResponse(httpx2.codes.OK),
     ]
     transport = _mock_transport(responses)  # type: ignore[arg-type]
 
@@ -297,7 +297,7 @@ async def test_async_context_manager_closes_transport():
 def test_wait_strategy_ignores_429_without_should_wait():
     """Ensure a 429 lacking the Should-Wait header skips the backoff entirely."""
     wait = wait_exponential_ignore_429(max=60)
-    state = _retry_state(result=httpx.Response(429), attempt_number=3)
+    state = _retry_state(result=httpx2.Response(429), attempt_number=3)
 
     assert wait(state) == 0
 
@@ -306,7 +306,7 @@ def test_wait_strategy_backs_off_for_429_with_should_wait():
     """Ensure a 429 carrying the Should-Wait header falls back to exponential backoff."""
     wait = wait_exponential_ignore_429(max=60)
     state = _retry_state(
-        result=httpx.Response(429, headers={"Should-Wait": "true"}), attempt_number=2
+        result=httpx2.Response(429, headers={"Should-Wait": "true"}), attempt_number=2
     )
 
     assert wait(state) == 2
@@ -315,7 +315,7 @@ def test_wait_strategy_backs_off_for_429_with_should_wait():
 def test_wait_strategy_backs_off_for_other_status():
     """Ensure non-429 responses use the regular exponential backoff."""
     wait = wait_exponential_ignore_429(max=60)
-    state = _retry_state(result=httpx.Response(503), attempt_number=3)
+    state = _retry_state(result=httpx2.Response(503), attempt_number=3)
 
     assert wait(state) == 4
 
@@ -323,7 +323,7 @@ def test_wait_strategy_backs_off_for_other_status():
 def test_wait_strategy_caps_at_max():
     """Ensure the computed backoff never exceeds the configured maximum."""
     wait = wait_exponential_ignore_429(max=5)
-    state = _retry_state(result=httpx.Response(503), attempt_number=10)
+    state = _retry_state(result=httpx2.Response(503), attempt_number=10)
 
     assert wait(state) == 5
 
@@ -331,7 +331,7 @@ def test_wait_strategy_caps_at_max():
 def test_wait_strategy_handles_failed_outcome():
     """Ensure a failed outcome is backed off without inspecting a result."""
     wait = wait_exponential_ignore_429(max=60)
-    state = _retry_state(exception=httpx.ConnectError("boom"), attempt_number=1)
+    state = _retry_state(exception=httpx2.ConnectError("boom"), attempt_number=1)
 
     assert wait(state) == 1
 
@@ -351,7 +351,7 @@ def test_log_before_attempt_records_attempt(caplog: pytest.LogCaptureFixture):
 
 def test_log_retry_stats_includes_response_status(caplog: pytest.LogCaptureFixture):
     """Ensure that for a response outcome the stats logger records the status code."""
-    state = _retry_state(fn=_named_function, result=httpx.Response(503))
+    state = _retry_state(fn=_named_function, result=httpx2.Response(503))
 
     with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
         _log_retry_stats(state)
@@ -361,11 +361,11 @@ def test_log_retry_stats_includes_response_status(caplog: pytest.LogCaptureFixtu
 
 def test_log_retry_stats_includes_exception_details(caplog: pytest.LogCaptureFixture):
     """Ensure that for a failed outcome the stats logger records the exception type and message."""
-    state = _retry_state(fn=_named_function, exception=httpx.ConnectError("boom"))
+    state = _retry_state(fn=_named_function, exception=httpx2.ConnectError("boom"))
 
     with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
         _log_retry_stats(state)
 
     record = caplog.records[0]
-    assert record.exception_type is httpx.ConnectError  # type: ignore[attr-defined]
+    assert record.exception_type is httpx2.ConnectError  # type: ignore[attr-defined]
     assert "boom" in record.exception_message  # type: ignore[attr-defined]

--- a/tests/unit/utils/test_crypt4gh.py
+++ b/tests/unit/utils/test_crypt4gh.py
@@ -36,7 +36,7 @@ FILE_SIZES = [1024**2, 64 * 1024**2, 1000**2, 64 * 1000**2]
 
 
 @pytest.mark.parametrize(
-    "file_size, use_path", zip(FILE_SIZES[:2], [True, False], strict=True)
+    "file_size, use_path", list(zip(FILE_SIZES[:2], [True, False], strict=True))
 )
 def test_crypt4gh_utilities_bytes(file_size: int, use_path: bool):
     """Test Crypt4GH functionality wrappers in sequence with bytes type arguments."""
@@ -83,7 +83,7 @@ def test_crypt4gh_utilities_bytes(file_size: int, use_path: bool):
 
 
 @pytest.mark.parametrize(
-    "file_size, use_path", zip(FILE_SIZES[2:], [True, False], strict=True)
+    "file_size, use_path", list(zip(FILE_SIZES[2:], [True, False], strict=True))
 )
 def test_crypt4gh_utilities_str(file_size: int, use_path: bool):
     """Test Crypt4GH functionality wrappers in sequence with str type arguments."""


### PR DESCRIPTION
This PR migrates the repo from from `httpx` to `httpx2`.
The version is bumped to 8.0.0.

# Major
- Drops `hishel` based caching transport, as it does not support `httpx2` and is currently unused across the GHGA service landscape.

# Minor
- Added `as_transport()` method to mock_router, which should be used as transport for simple clients targeting the `MockRouter`, replacing the use of `httpx_mock` in that context.

# Misc
Addressed a few issues in the test code that made it skip tests when run in VSCode, but not in the CLI
  - Replaced a 2s sleep with polling
  - Converted a `zip` used as parameter into a `list(zip(...))`
  - Changed `test_api.py` to actually test the async code
  - Restore log handlers after `test_uvicorn_log_format`